### PR TITLE
Implement `huff_[dd]_{pc,ps,naive}`

### DIFF
--- a/include/huffman/huff_dd.hpp
+++ b/include/huffman/huff_dd.hpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * include/huffman/huff_dd.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <omp.h>
+#include <vector>
+
+#include "construction/wavelet_structure.hpp"
+#include "arrays/slice.hpp"
+
+#include "huffman/huff_merge.hpp"
+#include "huffman/huff_bit_vectors.hpp"
+#include "huffman/huff_codes.hpp"
+#include "huffman/ctx_huff_all_levels.hpp"
+#include "huffman/huff_parallel_level_sizes_builder.hpp"
+
+template <typename Algorithm, typename AlphabetType, bool is_tree_>
+class huff_dd {
+
+public:
+  static constexpr bool  is_parallel = true;
+  static constexpr bool  is_tree   = is_tree_;
+  static constexpr uint8_t word_width  = sizeof(AlphabetType);
+  static constexpr bool  is_huffman_shaped = true;
+
+  using ctx_t = ctx_huff_all_levels<is_tree>;
+
+  template <typename InputType>
+  static wavelet_structure compute(const InputType& global_text,
+    const uint64_t size, const uint64_t /*levels*/) {
+
+    // TODO ^ remove levels parameter from API
+
+    const uint64_t shards = omp_get_max_threads();
+
+    std::vector<histogram<AlphabetType>> local_hists(shards);
+
+    auto get_local_text = [global_text, size, shards] (size_t rank) {
+      const uint64_t local_size = (size / shards) +
+        ((rank < size % shards) ? 1 : 0);
+      const uint64_t offset = (rank * (size / shards)) +
+        std::min<uint64_t>(rank, size % shards);
+
+      const AlphabetType* local_text = global_text + offset;
+
+      return Slice<AlphabetType const> { local_text, local_size };
+    };
+
+    #pragma omp parallel for
+    for (size_t shard = 0; shard < shards; shard++) {
+      auto text = get_local_text(shard);
+
+      // calculate local histogram
+      local_hists[shard] = histogram<AlphabetType>(text.data(), text.size());
+    }
+
+    // merge local histograms
+    histogram<AlphabetType> merged_hist(local_hists);
+
+    // prepare level size builder
+    auto builder = parallel_level_sizes_builder<AlphabetType> {
+        std::move(merged_hist),
+        std::move(local_hists),
+    };
+
+    // build huffman codes and calculate level sizes
+    canonical_huff_codes<AlphabetType, is_tree> codes
+      = canonical_huff_codes<AlphabetType, is_tree>(builder);
+    uint64_t const levels = builder.levels();
+
+    if(size == 0) {
+      if constexpr (ctx_t::compute_zeros) {
+        return wavelet_structure_matrix_huffman(std::move(codes));
+      } else {
+        return wavelet_structure_tree_huffman(std::move(codes));
+      }
+    }
+
+    const auto rho = rho_dispatch<is_tree>::create(levels);
+    auto ctxs = std::vector<ctx_t>(shards);
+
+    #pragma omp parallel for
+    for (size_t shard = 0; shard < shards; shard++) {
+      auto const text = get_local_text(shard);
+      std::vector<std::vector<uint64_t>> const& local_level_sizes
+        = builder.level_sizes_shards();
+
+      ctxs[shard] = ctx_t(local_level_sizes[shard], levels, rho);
+
+      Algorithm::calc_huff(text.data(), text.size(), levels, codes, ctxs[shard]);
+
+      ctxs[shard].discard_non_merge_data();
+    }
+
+    std::vector<uint64_t> const& level_sizes = builder.level_sizes();
+    auto bv = huff_merge_bit_vectors(level_sizes, shards, ctxs, rho);
+
+    if constexpr (ctx_t::compute_zeros) {
+      auto zeros = std::vector<uint64_t>(levels, 0);
+
+      for(size_t level = 0; level < levels; level++) {
+        for(size_t shard = 0; shard < ctxs.size(); shard++) {
+          zeros[level] += ctxs[shard].zeros()[level];
+        }
+      }
+
+      return wavelet_structure_matrix_huffman(
+        std::move(bv), std::move(zeros), std::move(codes));
+    } else {
+      return wavelet_structure_tree_huffman(
+        std::move(bv), std::move(codes));
+    }
+  }
+};
+
+/******************************************************************************/

--- a/include/huffman/huff_dd.hpp
+++ b/include/huffman/huff_dd.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "construction/wavelet_structure.hpp"
-#include "arrays/slice.hpp"
+#include "arrays/span.hpp"
 
 #include "huffman/huff_merge.hpp"
 #include "huffman/huff_bit_vectors.hpp"
@@ -40,7 +40,7 @@ public:
 
     // TODO ^ remove levels parameter from API
 
-    Slice<AlphabetType const> const global_text { global_text_ptr, size };
+    span<AlphabetType const> const global_text { global_text_ptr, size };
 
     const uint64_t shards = omp_get_max_threads();
 
@@ -93,7 +93,7 @@ public:
     if constexpr (Algorithm::needs_second_text_allocation) {
       global_sorted_text_allocation = std::vector<AlphabetType>(size);
     }
-    Slice<AlphabetType> const global_sorted_text {
+    span<AlphabetType> const global_sorted_text {
         global_sorted_text_allocation.data(),
         global_sorted_text_allocation.size()
     };

--- a/include/huffman/huff_merge.hpp
+++ b/include/huffman/huff_merge.hpp
@@ -1,0 +1,336 @@
+/*******************************************************************************
+ * include/huffman/huff_merge.hpp
+ *
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cassert>
+#include <climits>
+#include <omp.h>
+
+#include "huffman/huff_bit_vectors.hpp"
+#include "util/common.hpp"
+#include "util/macros.hpp"
+#include "construction/merge.hpp"
+
+template<typename ContextType, typename Rho>
+inline auto huff_merge_bit_vectors(std::vector<uint64_t> const& level_sizes,
+                                   uint64_t const shards,
+                                   const std::vector<ContextType>& src_ctxs,
+                                   const Rho& rho)
+{
+  assert(shards == src_ctxs.size());
+  assert(shards > 1);
+
+  uint64_t const levels = level_sizes.size();
+
+  // Allocate data structures centrally
+
+  struct MergeLevelCtx {
+    std::vector<uint64_t> read_offsets;
+    uint64_t initial_read_offset;
+    uint64_t first_read_block;
+    uint64_t write_end_offset;
+  };
+
+  struct MergeCtx {
+    std::vector<MergeLevelCtx> levels;
+  };
+
+  auto ctxs = std::vector<MergeCtx> { shards,
+    {
+      std::vector<MergeLevelCtx> { levels,
+        {
+          std::vector<uint64_t>(shards),
+          0,
+          0,
+          0,
+        }
+      },
+    }
+  };
+
+  /*
+    Visualization of ctxs for levels = 2 and shards = 2:
+    ┌──────────────┬───────────────────────┐
+    │ctxs: MergeCtx│ x shards              │
+    │ ┌────────────┴────────┬──────────────┤
+    │ │levels: MergeLevelCtx│ x levels     │
+    │ │ ┌───────────────────┴──────────────┤
+    │ │ │write_end_offset: uint64_t        │
+    │ │ ├──────────────────────────────────┤
+    │ │ │initial_read_offset: uint64_t     │
+    │ │ ├──────────────────────────────────┤
+    │ │ │first_read_block: uint64_t        │
+    │ │ ├──────────────────────┬───────────┤
+    │ │ │read_offsets: uint64_t│ x shards  │
+    │ │ │ ┌────────────────────┴───────────┤
+    │ │ │ │                                │
+    │ │ │ ╞════════════════════════════════╡
+    │ │ │ │                                │
+    │ │ ╞═╧════════════════════════════════╡
+    │ │ │initial_read_offset: uint64_t     │
+    │ │ ├──────────────────────────────────┤
+    │ │ │first_read_block: uint64_t        │
+    │ │ ├──────────────────────┬───────────┤
+    │ │ │read_offsets: uint64_t│ x shards  │
+    │ │ │ ┌────────────────────┴───────────┤
+    │ │ │ │                                │
+    │ │ │ ╞════════════════════════════════╡
+    │ │ │ │                                │
+    │ ╞═╧═╧════════════════════════════════╡
+    │ │levels: MergeLevelCtx│ x levels     │
+    │ │ ┌───────────────────┴──────────────┤
+    │ │ │write_end_offset: uint64_t        │
+    │ │ ├──────────────────────────────────┤
+    │ │ │initial_read_offset: uint64_t     │
+    │ │ ├──────────────────────────────────┤
+    │ │ │first_read_block: uint64_t        │
+    │ │ ├──────────────────────┬───────────┤
+    │ │ │read_offsets: uint64_t│ x shards  │
+    │ │ │ ┌────────────────────┴───────────┤
+    │ │ │ │                                │
+    │ │ │ ╞════════════════════════════════╡
+    │ │ │ │                                │
+    │ │ ╞═╧════════════════════════════════╡
+    │ │ │initial_read_offset: uint64_t     │
+    │ │ ├──────────────────────────────────┤
+    │ │ │first_read_block: uint64_t        │
+    │ │ ├──────────────────────┬───────────┤
+    │ │ │read_offsets: uint64_t│ x shards  │
+    │ │ │ ┌────────────────────┴───────────┤
+    │ │ │ │                                │
+    │ │ │ ╞════════════════════════════════╡
+    │ │ │ │                                │
+    └─┴─┴─┴────────────────────────────────┘
+  */
+
+  // Calculate end bit offset per merge shard (thread).
+  // It is an multiple of 64, to ensure no interference
+  // in writing bits to the left or right of it in parallel
+  for(size_t level = 0; level < levels; level++) {
+    const size_t size = level_sizes[level];
+    for (size_t shard = 1; shard < shards; shard++) {
+      const uint64_t offset = (shard * (word_size(size) / shards)) +
+        std::min<uint64_t>(shard, word_size(size) % shards);
+
+      ctxs[shard - 1].levels[level].write_end_offset
+        = std::min<uint64_t>(offset * 64ull, size);
+    }
+    ctxs[shards - 1].levels[level].write_end_offset
+      = std::min<uint64_t>(word_size(size) * 64ull, size);
+  }
+
+  for(size_t level = 0; level < levels; level++) {
+    // number of tree nodes on the current level
+    const size_t blocks = 1ull << level;
+
+    size_t write_offset = 0; // bit offset in destination bv
+    size_t merge_shard = 0; // index of merge thread
+
+    // iterate over all blocks of all shards on the current level
+    //
+    // this gradually assigns the bits of the
+    // blocks to each of the aviable merge shards of the current level:
+    //
+    // |   read_shard  |   read_shard  |
+    // +---------------+---------------+
+    // |     block     |     block     |
+    // | block | block | block | block | <- current level
+    // +----------+----------+---------+
+    // | m. shard | m. shard |m. shard |
+    //
+    for(size_t i = 0; i < blocks * shards; i++) {
+      // std::cout << "[offsets]   i: " << i << "\n";
+
+      // returns merge level context of merge_shard
+      auto lctx = [&level, &ctxs](auto merge_shard) -> MergeLevelCtx& {
+          return ctxs[merge_shard].levels[level];
+      };
+
+      // returns merge level context of merge_shard+1
+      auto nxt_lctx = [&level, &ctxs](auto merge_shard) -> MergeLevelCtx& {
+          return ctxs[merge_shard + 1].levels[level];
+      };
+
+      // which block (node on current level of tree)
+      const auto block = i / shards;
+
+      // which shard to read from
+      const auto read_shard = i % shards;
+
+      // map logical block index to
+      // actual block index (rho depends on WT vs WM)
+      const auto permuted_block = rho(level, block);
+
+      // block size == number of entries in the block on this level
+      auto block_size = src_ctxs[read_shard].hist(level, permuted_block);
+
+      // advance global write offset by the number of bits assigned for
+      // this block
+      write_offset += block_size;
+
+
+      // advance local read offset of next merge shard
+      // for the curent read shard
+      //
+      // this way, all merge shard start reading
+      // at different offsets from the read shards
+      nxt_lctx(merge_shard).read_offsets[read_shard] += block_size;
+
+      // If we passed the current right border, split up the block
+      if (write_offset > lctx(merge_shard).write_end_offset) {
+        // Take back the last step
+        write_offset -= block_size;
+        nxt_lctx(merge_shard).read_offsets[read_shard] -= block_size;
+
+        uint64_t initial_read_offset = 0;
+        do {
+          // Split up the block like this:
+          //     [  left_block_size  |    right_block_size    ]
+          //     ^                   ^                        ^
+          // (write_offset)          |                        |
+          //           (ctxs[merge_shard].write_end_offset)   |
+          //                              (write_offset + block_size)
+          //
+          // this loop iterates multiple times, to ensure right_block_size
+          // did not also overlap the next write_end_offset
+
+          auto const left_block_size
+            = lctx(merge_shard).write_end_offset - write_offset;
+
+          // advance global and local read offsets to end exactly at
+          // write_end_offset
+          write_offset += left_block_size;
+          nxt_lctx(merge_shard).read_offsets[read_shard] += left_block_size;
+
+          initial_read_offset += left_block_size;
+
+          // from which offset in which block to start reading
+          nxt_lctx(merge_shard).initial_read_offset = initial_read_offset;
+          nxt_lctx(merge_shard).first_read_block = i;
+
+          // if there is a merge_shard to the right
+          // of the next merge shard, intialize
+          // its local read offsets with those of the next shard
+          if (merge_shard + 2 < shards) {
+            for(size_t s = 0; s < shards; s++) {
+              nxt_lctx(merge_shard + 1).read_offsets[s]
+                = nxt_lctx(merge_shard).read_offsets[s];
+            }
+          }
+
+          merge_shard++;
+
+          // Once we have calculated the offsets for all merge threads,
+          // break out of the whole nested loop
+          if (merge_shard + 1 == shards) {
+            goto triple_loop_exit;
+          }
+
+          // Iterate on remaining block, because one block might
+          // span multiple threads
+          block_size -= left_block_size;
+        } while ((write_offset + block_size) > lctx(merge_shard).write_end_offset);
+
+        // Process remainder of block
+        write_offset += block_size;
+        nxt_lctx(merge_shard).read_offsets[read_shard] += block_size;
+
+        assert(write_offset <= lctx(merge_shard).write_end_offset);
+      }
+    }
+    triple_loop_exit:; // we are done
+  }
+
+  // TODO: remove redundant argument
+  auto r =  huff_bit_vectors(levels, level_sizes);
+  auto& _bv = r;
+
+  // TODO: Bugs
+
+  //#pragma omp parallel
+  for(size_t merge_shard = 0; merge_shard < shards; merge_shard++)
+  {
+    auto& ctx = ctxs[merge_shard];
+
+    for (size_t level = 0; level < levels; level++) {
+      const auto target_right = std::min(
+        ctx.levels[level].write_end_offset,
+        level_sizes[level]);
+      const auto target_left = std::min(
+        (merge_shard > 0 ? ctxs[merge_shard - 1].levels[level].write_end_offset : 0),
+        target_right);
+
+      // std::cout << "\n";
+      // std::cout << "[merge] target_{left,right}: " << target_left;
+      // std::cout << ", " << target_right << "\n";
+
+      auto i = ctx.levels[level].first_read_block;
+      uint64_t write_offset = target_left;
+
+      auto copy_next_block = [&](size_t const initial_read_offset) {
+        // std::cout << "\n";
+        // std::cout << "[merge] i: " << i << "\n";
+        // std::cout << "[merge] write_offset: " << write_offset << "\n";
+        // std::cout << "[merge] initial_read_offset: " << initial_read_offset << "\n";
+
+        const auto block = i / shards;
+        const auto read_shard = i % shards;
+        i++;
+
+        // std::cout << "[merge] block: " << block << "\n";
+        // std::cout << "[merge] read_shard: " << read_shard << "\n";
+
+        const auto& local_bv = src_ctxs[read_shard].bv()[level];
+        const auto& h = src_ctxs[read_shard];
+        auto const permuted_block = rho(level, block);
+        uint64_t block_size = h.hist(level, permuted_block) - initial_read_offset;
+        uint64_t distance_to_end = target_right - write_offset;
+
+        // std::cout << "[merge] block_size: " << block_size << "\n";
+        // std::cout << "[merge] distance_to_end: " << distance_to_end << "\n";
+
+        uint64_t copy_size;
+        if (PWM_LIKELY(block_size <= distance_to_end)) {
+            copy_size = block_size;
+        } else {
+            copy_size = distance_to_end;
+        }
+
+        auto& local_cursor = ctx.levels[level].read_offsets[read_shard];
+
+        // std::cout << "[merge] copy_bits("
+        //     << "write_offset=" << write_offset << ", "
+        //     << "local_cursor=" << local_cursor << ", "
+        //     << "copy_size=" << copy_size << ")"
+        //     << "\n";
+        copy_bits<uint64_t>(
+          _bv[level].data(),
+          local_bv.data(),
+          write_offset,
+          local_cursor,
+          copy_size
+        );
+      };
+
+      if (write_offset < target_right) {
+        // the first block might start somewhere in the middle
+        copy_next_block(ctx.levels[level].initial_read_offset);
+      }
+      while (write_offset < target_right) {
+        // other blocks start at 0
+        copy_next_block(0);
+      }
+      assert(write_offset == target_right);
+    }
+  }
+
+  return r;
+}
+
+/******************************************************************************/

--- a/include/huffman/huff_naive.hpp
+++ b/include/huffman/huff_naive.hpp
@@ -29,6 +29,8 @@ void huff_naive(AlphabetType const* text,
 
       // calculate histogram
       {
+        // TODO: Only calculate if needed? Right now needed for dd,
+        // but not for standalone.
         for(size_t i = 0; i < size; i++) {
             const code_pair cp = codes.encode_symbol(text[i]);
             for (size_t level = 0; level <= cp.code_length; level++) {

--- a/include/huffman/huff_naive.hpp
+++ b/include/huffman/huff_naive.hpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * include/huffman/huff_naive.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+template <typename AlphabetType, typename ContextType, typename HuffCodes>
+void huff_naive(AlphabetType const* text,
+                uint64_t const size,
+                uint64_t const levels,
+                HuffCodes const& codes,
+                ContextType& ctx)
+{
+      constexpr bool is_tree = !ContextType::compute_zeros;
+
+      auto& bv = ctx.bv();
+      auto& zeros = ctx.zeros();
+
+      // calculate histogram
+      {
+        for(size_t i = 0; i < size; i++) {
+            const code_pair cp = codes.encode_symbol(text[i]);
+            for (size_t level = 0; level <= cp.code_length; level++) {
+                auto prefix = cp.prefix(level);
+                ctx.hist(level, prefix)++;
+            }
+        }
+      }
+
+      std::vector<AlphabetType> local_text(size);
+      for(size_t i = 0; i < size; i++) {
+        local_text[i] = text[i];
+      }
+      // Construct each level top-down
+      for (uint64_t level = 0; level < levels; ++level) {
+        std::vector<AlphabetType> text0;
+        std::vector<AlphabetType> text1;
+
+        // Insert the level-th MSB in the bit vector of the level (in text order)
+        uint32_t cur_pos = 0;
+        // Eat prefix in whole 64bit word chunks.
+        // Modification of local_text ensures its only as long as the level.
+        for (; cur_pos + 64 <= local_text.size(); cur_pos += 64) {
+          uint64_t word = 0ULL;
+          for (uint32_t i = 0; i < 64; ++i) {
+            const code_pair cp = codes.encode_symbol(local_text[cur_pos + i]);
+            word <<= 1;
+            word |= cp[level];
+            if constexpr (!is_tree) {
+              if (cp.code_length > level + 1) {
+                if (cp[level]) { text1.emplace_back(local_text[cur_pos + i]); }
+                else { text0.emplace_back(local_text[cur_pos + i]); }
+              }
+            }
+          }
+          if constexpr (!is_tree) {
+            zeros[level] += __builtin_popcountll(~word);
+          }
+          bv[level][cur_pos >> 6] = word;
+        }
+
+        // if there are remaining odd bits...
+        if (local_text.size() & 63ULL) {
+          uint64_t word = 0ULL;
+          for (uint32_t i = cur_pos; i < local_text.size(); ++i) {
+            const code_pair cp = codes.encode_symbol(local_text[i]);
+            word <<= 1;
+            word |= cp[level];
+            if constexpr (!is_tree) {
+              if (cp.code_length > level + 1) {
+                if (cp[level]) {
+                  text1.emplace_back(local_text[i]);
+                }
+                else {
+                  text0.emplace_back(local_text[i]);
+                }
+              }
+            }
+          }
+          word <<= (64 - (local_text.size() & 63ULL));
+          bv[level][local_text.size() >> 6] = word;
+          if constexpr (!is_tree) {
+            zeros[level] +=
+              (local_text.size() & 63ULL) - __builtin_popcountll(word);
+          }
+        }
+
+        if constexpr (is_tree) {
+          std::vector<std::vector<AlphabetType>> buckets(1ULL << (level + 1));
+
+          for (uint64_t i = 0; i < local_text.size(); ++i) {
+            const AlphabetType cur_symbol = local_text[i];
+            if (codes.code_length(cur_symbol) > level + 1) {
+              // prefix gets the prefix bits of the codeword
+              buckets[codes.encode_symbol(cur_symbol).prefix(level + 1)]
+                .emplace_back(cur_symbol);
+            }
+          }
+
+          for (uint64_t i = 1; i < buckets.size(); ++i) {
+            std::move(buckets[i].begin(), buckets[i].end(),
+              std::back_inserter(buckets[0]));
+          }
+          local_text.swap(buckets[0]);
+        } else /*if constexpr (!is_tree)*/ {
+          std::move(text1.begin(), text1.end(), std::back_inserter(text0));
+          local_text = std::move(text0);
+        }
+      }
+}
+
+/******************************************************************************/

--- a/include/huffman/huff_naive.hpp
+++ b/include/huffman/huff_naive.hpp
@@ -9,6 +9,12 @@
 
 #pragma once
 
+#include <cstdint>
+#include <cstddef>
+#include <iostream>
+
+#include "huffman/huff_codes.hpp"
+
 template <typename AlphabetType, typename ContextType, typename HuffCodes>
 void huff_naive(AlphabetType const* text,
                 uint64_t const size,

--- a/include/huffman/huff_parallel_level_sizes_builder.hpp
+++ b/include/huffman/huff_parallel_level_sizes_builder.hpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * include/huffman/huff_parallel_level_sizes_builder.hpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include "util/common.hpp"
+
+template<typename AlphabetType>
+class parallel_level_sizes_builder {
+  histogram<AlphabetType> m_hist;
+  std::vector<histogram<AlphabetType>> m_hists;
+
+  std::vector<uint64_t> global_level_sizes;
+  std::vector<std::vector<uint64_t>> local_level_sizes;
+
+  inline size_t shards() {
+    return m_hists.size();
+  }
+public:
+  // init
+  parallel_level_sizes_builder(histogram<AlphabetType>&& h,
+                               std::vector<histogram<AlphabetType>>&& hs):
+    m_hist(h), m_hists(hs) {}
+  inline void allocate_levels(size_t levels) {
+    global_level_sizes = std::vector<uint64_t>(levels, 0);
+    local_level_sizes.resize(shards());
+    for (auto& e : local_level_sizes) {
+      e = std::vector<uint64_t>(levels, 0);
+    }
+  }
+  inline void count(size_t level, AlphabetType symbol) {
+    for (size_t i = 0; i < shards(); i++) {
+      auto freq = m_hists[i].frequency(symbol);
+      global_level_sizes[level] += freq;
+      local_level_sizes[i][level] += freq;
+    }
+  }
+  inline histogram<AlphabetType> const& get_histogram() const {
+    return m_hist;
+  }
+
+  // finalization
+  inline void drop_hist_and_finalize_level_sizes() {
+    for (uint64_t i = global_level_sizes.size() - 1; i > 0; --i) {
+      global_level_sizes[i - 1] += global_level_sizes[i];
+    }
+    for (size_t j = 0; j < shards(); j++) {
+      for (uint64_t i = local_level_sizes[j].size() - 1; i > 0; --i) {
+        local_level_sizes[j][i - 1] += local_level_sizes[j][i];
+      }
+    }
+    drop_me(std::move(m_hist));
+    drop_me(std::move(m_hists));
+  }
+
+  // final data
+  inline size_t levels() const { return level_sizes().size(); }
+  inline std::vector<uint64_t> const& level_sizes() const {
+    return global_level_sizes;
+  }
+  inline std::vector<std::vector<uint64_t>> const& level_sizes_shards() const {
+    return local_level_sizes;
+  }
+};
+
+/******************************************************************************/

--- a/include/huffman/huff_pc.hpp
+++ b/include/huffman/huff_pc.hpp
@@ -8,6 +8,12 @@
 
 #pragma once
 
+#include <cstdint>
+#include <cstddef>
+#include <iostream>
+
+#include "huffman/huff_codes.hpp"
+
 template <typename AlphabetType, typename ContextType, typename HuffCodes>
 void huff_pc(AlphabetType const* text,
              uint64_t const size,

--- a/include/huffman/huff_pc.hpp
+++ b/include/huffman/huff_pc.hpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * include/huffman/huff_pc.hpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+template <typename AlphabetType, typename ContextType, typename HuffCodes>
+void huff_pc(AlphabetType const* text,
+             uint64_t const size,
+             uint64_t const levels,
+             HuffCodes const& codes,
+             ContextType& ctx)
+{
+  auto& zeros = ctx.zeros();
+  auto& borders = ctx.borders();
+  auto& bv = ctx.bv();
+
+  // While calculating the histogram, we also compute the first level
+  {
+    ctx.hist(0, 0) = size;
+
+    auto process_symbol = [&](auto& word, auto pos) {
+      const code_pair cp = codes.encode_symbol(text[pos]);
+      word <<= 1;
+      word |= cp[0];
+      for (size_t level = 1; level <= cp.code_length; level++) {
+        auto prefix = cp.prefix(level);
+        ctx.hist(level, prefix)++;
+      }
+    };
+
+    uint64_t cur_pos = 0;
+    for (; cur_pos + 64 <= size; cur_pos += 64) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < 64; ++i) {
+        process_symbol(word, cur_pos + i);
+      }
+      bv[0][cur_pos >> 6] = word;
+    }
+    if (size & 63ULL) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < size - cur_pos; ++i) {
+        process_symbol(word, cur_pos + i);
+      }
+      word <<= (64 - (size & 63ULL));
+      bv[0][size >> 6] = word;
+    }
+  }
+
+  // Now we compute the WX top-down, since the histograms are already computed
+  for (uint64_t level = 1; level < levels; level++) {
+    uint64_t blocks = 1ull << level;
+
+    // Compute the starting positions of characters with respect to their
+    // bit prefixes and the bit-reversal permutation
+    borders[0] = 0;
+    for (uint64_t i = 1; i < blocks; ++i) {
+      auto const prev_block = ctx.rho(level, i - 1);
+      auto const this_block = ctx.rho(level, i);
+
+      borders[this_block] = borders[prev_block] + ctx.hist(level, prev_block);
+      // NB: The above calulcation produces _wrong_ border offsets
+      // for huffman codes that are one-shorter than the current level.
+      //
+      // Since those codes will not be used in the loop below, this does not
+      // produce wrong or out-of-bound accesses.
+
+      DCHECK(!ContextType::compute_rho);
+      // TODO: Due to the forward iteration, this can not currently work
+      /*
+      if (ContextType::compute_rho)  {
+        ctx.set_rho(level - 1, i - 1, prev_block >> 1);
+      }
+      */
+    }
+
+    if (ContextType::compute_zeros) {
+      // If we compute zeros, we are working on a WM instead of a WT.
+      // For a WM, borders is permuted with rho such that
+      // borders[1] contains the position of the first 1-bit block.
+      zeros[level - 1] = borders[1];
+    }
+
+    // Now we insert the bits with respect to their bit prefixes
+    for (uint64_t i = 0; i < size; ++i) {
+      const code_pair cp = codes.encode_symbol(text[i]);
+      if (level < cp.code_length) {
+        uint64_t const prefix = cp.prefix(level);
+        uint64_t const pos = borders[prefix]++;
+        uint64_t const bit = cp[level];
+        uint64_t const word_pos = 63ULL - (pos & 63ULL);
+        bv[level][pos >> 6] |= (bit << word_pos);
+      }
+    }
+  }
+}
+
+/******************************************************************************/

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * include/huffman/huff_ps.hpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <iostream>
+
+#include "huffman/huff_codes.hpp"
+
+template <typename AlphabetType, typename ContextType, typename HuffCodes>
+void huff_ps(AlphabetType const* text,
+             uint64_t const size,
+             uint64_t const levels,
+             HuffCodes const& codes,
+             ContextType& ctx,
+             AlphabetType* const sorted_text,
+             std::vector<uint64_t> const& level_sizes)
+{
+  auto& zeros = ctx.zeros();
+  auto& borders = ctx.borders();
+  auto& bv = ctx.bv();
+
+  // While calculating the histogram, we also compute the first level
+  {
+    ctx.hist(0, 0) = size;
+
+    auto process_symbol = [&](auto& word, auto pos) {
+      const code_pair cp = codes.encode_symbol(text[pos]);
+      word <<= 1;
+      word |= cp[0];
+      for (size_t level = 1; level <= cp.code_length; level++) {
+        auto prefix = cp.prefix(level);
+        ctx.hist(level, prefix)++;
+      }
+    };
+
+    uint64_t cur_pos = 0;
+    for (; cur_pos + 64 <= size; cur_pos += 64) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < 64; ++i) {
+        process_symbol(word, cur_pos + i);
+      }
+      bv[0][cur_pos >> 6] = word;
+    }
+    if (size & 63ULL) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < size - cur_pos; ++i) {
+        process_symbol(word, cur_pos + i);
+      }
+      word <<= (64 - (size & 63ULL));
+      bv[0][size >> 6] = word;
+    }
+  }
+
+  // Now we compute the WX top-down, since the histograms are already computed
+  for (uint64_t level = 1; level < levels; level++) {
+    uint64_t blocks = 1ull << level;
+
+    // Compute the starting positions of characters with respect to their
+    // bit prefixes and the bit-reversal permutation
+    borders[0] = 0;
+    for (uint64_t i = 1; i < blocks; ++i) {
+      auto const prev_block = ctx.rho(level, i - 1);
+      auto const this_block = ctx.rho(level, i);
+
+      borders[this_block] = borders[prev_block] + ctx.hist(level, prev_block);
+      // NB: The above calulcation produces _wrong_ border offsets
+      // for huffman codes that are one-shorter than the current level.
+      //
+      // Since those codes will not be used in the loop below, this does not
+      // produce wrong or out-of-bound accesses.
+
+      DCHECK(!ContextType::compute_rho);
+      // TODO: Due to the forward iteration, this can not currently work
+      /*
+      if (ContextType::compute_rho)  {
+        ctx.set_rho(level - 1, i - 1, prev_block >> 1);
+      }
+      */
+    }
+
+    if (ContextType::compute_zeros) {
+      // If we compute zeros, we are working on a WM instead of a WT.
+      // For a WM, borders is permuted with rho such that
+      // borders[1] contains the position of the first 1-bit block.
+      zeros[level - 1] = borders[1];
+    }
+
+    // Now we sort the text utilizing counting sort and the starting positions
+    // that we have computed before
+    for (uint64_t i = 0; i < size; ++i) {
+      auto const cur_char = text[i];
+      const code_pair cp = codes.encode_symbol(cur_char);
+
+      if (level < cp.code_length) {
+        uint64_t const prefix = cp.prefix(level);
+        uint64_t const pos = borders[prefix]++;
+        sorted_text[pos] = cur_char;
+      }
+    }
+
+    uint64_t const level_size = level_sizes[level];
+
+    // Now we insert the bits with respect to their bit prefixes
+    for (uint64_t i = 0; i < level_size; ++i) {
+      const code_pair cp = codes.encode_symbol(sorted_text[i]);
+      DCHECK(level < cp.code_length);
+
+      uint64_t const bit = cp[level];
+
+      // TODO: Write 1-word at a time
+      uint64_t const word_pos = 63ULL - (i & 63ULL);
+      bv[level][i >> 6] |= (bit << word_pos);
+    }
+  }
+}
+
+/******************************************************************************/

--- a/include/wx_huff_dd_naive.hpp
+++ b/include/wx_huff_dd_naive.hpp
@@ -1,125 +1,30 @@
 /*******************************************************************************
- * include/wx_dd_naive.hpp
+ * include/wx_huff_dd_naive.hpp
  *
  * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
  *
  * All rights reserved. Published under the BSD-2 license in the LICENSE file.
  ******************************************************************************/
 
 #pragma once
 
-#include <algorithm>
-#include <cstring>
-#include <omp.h>
-#include <vector>
-
-#include "construction/wavelet_structure.hpp"
-#include "arrays/slice.hpp"
-
-#include "huffman/huff_merge.hpp"
-#include "huffman/huff_bit_vectors.hpp"
-#include "huffman/huff_codes.hpp"
-#include "huffman/ctx_huff_all_levels.hpp"
 #include "huffman/huff_naive.hpp"
-#include "huffman/huff_parallel_level_sizes_builder.hpp"
+#include "huffman/huff_dd.hpp"
+
+struct huff_naive_disp {
+  template <typename AlphabetType, typename ContextType, typename HuffCodes>
+  static void calc_huff(AlphabetType const* text,
+                        uint64_t const size,
+                        uint64_t const levels,
+                        HuffCodes const& codes,
+                        ContextType& ctx)
+  {
+    huff_naive(text, size, levels, codes, ctx);
+  }
+};
 
 template <typename AlphabetType, bool is_tree_>
-class wx_huff_dd_naive {
-
-public:
-  static constexpr bool  is_parallel = true;
-  static constexpr bool  is_tree   = is_tree_;
-  static constexpr uint8_t word_width  = sizeof(AlphabetType);
-  static constexpr bool  is_huffman_shaped = true;
-
-  using ctx_t = ctx_huff_all_levels<is_tree>;
-
-  template <typename InputType>
-  static wavelet_structure compute(const InputType& global_text,
-    const uint64_t size, const uint64_t /*levels*/) {
-
-    // TODO ^ remove levels parameter from API
-
-    const uint64_t shards = omp_get_max_threads();
-
-    std::vector<histogram<AlphabetType>> local_hists(shards);
-
-    auto get_local_text = [global_text, size, shards] (size_t rank) {
-      const uint64_t local_size = (size / shards) +
-        ((rank < size % shards) ? 1 : 0);
-      const uint64_t offset = (rank * (size / shards)) +
-        std::min<uint64_t>(rank, size % shards);
-
-      const AlphabetType* local_text = global_text + offset;
-
-      return Slice<AlphabetType const> { local_text, local_size };
-    };
-
-    #pragma omp parallel for
-    for (size_t shard = 0; shard < shards; shard++) {
-      auto text = get_local_text(shard);
-
-      // calculate local histogram
-      local_hists[shard] = histogram<AlphabetType>(text.data(), text.size());
-    }
-
-    // merge local histograms
-    histogram<AlphabetType> merged_hist(local_hists);
-
-    // prepare level size builder
-    auto builder = parallel_level_sizes_builder<AlphabetType> {
-        std::move(merged_hist),
-        std::move(local_hists),
-    };
-
-    // build huffman codes and calculate level sizes
-    canonical_huff_codes<AlphabetType, is_tree> codes
-      = canonical_huff_codes<AlphabetType, is_tree>(builder);
-    uint64_t const levels = builder.levels();
-
-    if(size == 0) {
-      if constexpr (ctx_t::compute_zeros) {
-        return wavelet_structure_matrix_huffman(std::move(codes));
-      } else {
-        return wavelet_structure_tree_huffman(std::move(codes));
-      }
-    }
-
-    const auto rho = rho_dispatch<is_tree>::create(levels);
-    auto ctxs = std::vector<ctx_t>(shards);
-
-    #pragma omp parallel for
-    for (size_t shard = 0; shard < shards; shard++) {
-      auto const text = get_local_text(shard);
-      std::vector<std::vector<uint64_t>> const& local_level_sizes
-        = builder.level_sizes_shards();
-
-      ctxs[shard] = ctx_t(local_level_sizes[shard], levels, rho);
-
-      huff_naive(text.data(), text.size(), levels, codes, ctxs[shard]);
-
-      ctxs[shard].discard_non_merge_data();
-    }
-
-    std::vector<uint64_t> const& level_sizes = builder.level_sizes();
-    auto bv = huff_merge_bit_vectors(level_sizes, shards, ctxs, rho);
-
-    if constexpr (ctx_t::compute_zeros) {
-      auto zeros = std::vector<uint64_t>(levels, 0);
-
-      for(size_t level = 0; level < levels; level++) {
-        for(size_t shard = 0; shard < ctxs.size(); shard++) {
-          zeros[level] += ctxs[shard].zeros()[level];
-        }
-      }
-
-      return wavelet_structure_matrix_huffman(
-        std::move(bv), std::move(zeros), std::move(codes));
-    } else {
-      return wavelet_structure_tree_huffman(
-        std::move(bv), std::move(codes));
-    }
-  }
-}; // class wx_huff_dd_naive
+using wx_huff_dd_naive = huff_dd<huff_naive_disp, AlphabetType, is_tree_>;
 
 /******************************************************************************/

--- a/include/wx_huff_dd_naive.hpp
+++ b/include/wx_huff_dd_naive.hpp
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * include/wx_dd_naive.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <omp.h>
+#include <vector>
+
+#include "construction/wavelet_structure.hpp"
+#include "arrays/slice.hpp"
+
+#include "huffman/huff_merge.hpp"
+#include "huffman/huff_bit_vectors.hpp"
+#include "huffman/huff_codes.hpp"
+#include "huffman/ctx_huff_all_levels.hpp"
+#include "huffman/huff_naive.hpp"
+#include "huffman/huff_parallel_level_sizes_builder.hpp"
+
+template <typename AlphabetType, bool is_tree_>
+class wx_huff_dd_naive {
+
+public:
+  static constexpr bool  is_parallel = true;
+  static constexpr bool  is_tree   = is_tree_;
+  static constexpr uint8_t word_width  = sizeof(AlphabetType);
+  static constexpr bool  is_huffman_shaped = true;
+
+  using ctx_t = ctx_huff_all_levels<is_tree>;
+
+  template <typename InputType>
+  static wavelet_structure compute(const InputType& global_text,
+    const uint64_t size, const uint64_t /*levels*/) {
+
+    // TODO ^ remove levels parameter from API
+
+    const uint64_t shards = omp_get_max_threads();
+
+    std::vector<histogram<AlphabetType>> local_hists(shards);
+
+    auto get_local_text = [global_text, size, shards] (size_t rank) {
+      const uint64_t local_size = (size / shards) +
+        ((rank < size % shards) ? 1 : 0);
+      const uint64_t offset = (rank * (size / shards)) +
+        std::min<uint64_t>(rank, size % shards);
+
+      const AlphabetType* local_text = global_text + offset;
+
+      return Slice<AlphabetType const> { local_text, local_size };
+    };
+
+    #pragma omp parallel for
+    for (size_t shard = 0; shard < shards; shard++) {
+      auto text = get_local_text(shard);
+
+      // calculate local histogram
+      local_hists[shard] = histogram<AlphabetType>(text.data(), text.size());
+    }
+
+    // merge local histograms
+    histogram<AlphabetType> merged_hist(local_hists);
+
+    // prepare level size builder
+    auto builder = parallel_level_sizes_builder<AlphabetType> {
+        std::move(merged_hist),
+        std::move(local_hists),
+    };
+
+    // build huffman codes and calculate level sizes
+    canonical_huff_codes<AlphabetType, is_tree> codes
+      = canonical_huff_codes<AlphabetType, is_tree>(builder);
+    uint64_t const levels = builder.levels();
+
+    if(size == 0) {
+      if constexpr (ctx_t::compute_zeros) {
+        return wavelet_structure_matrix_huffman(std::move(codes));
+      } else {
+        return wavelet_structure_tree_huffman(std::move(codes));
+      }
+    }
+
+    const auto rho = rho_dispatch<is_tree>::create(levels);
+    auto ctxs = std::vector<ctx_t>(shards);
+
+    #pragma omp parallel for
+    for (size_t shard = 0; shard < shards; shard++) {
+      auto const text = get_local_text(shard);
+      std::vector<std::vector<uint64_t>> const& local_level_sizes
+        = builder.level_sizes_shards();
+
+      ctxs[shard] = ctx_t(local_level_sizes[shard], levels, rho);
+
+      huff_naive(text.data(), text.size(), levels, codes, ctxs[shard]);
+
+      ctxs[shard].discard_non_merge_data();
+    }
+
+    std::vector<uint64_t> const& level_sizes = builder.level_sizes();
+    auto bv = huff_merge_bit_vectors(level_sizes, shards, ctxs, rho);
+
+    if constexpr (ctx_t::compute_zeros) {
+      auto zeros = std::vector<uint64_t>(levels, 0);
+
+      for(size_t level = 0; level < levels; level++) {
+        for(size_t shard = 0; shard < ctxs.size(); shard++) {
+          zeros[level] += ctxs[shard].zeros()[level];
+        }
+      }
+
+      return wavelet_structure_matrix_huffman(
+        std::move(bv), std::move(zeros), std::move(codes));
+    } else {
+      return wavelet_structure_tree_huffman(
+        std::move(bv), std::move(codes));
+    }
+  }
+}; // class wx_huff_dd_naive
+
+/******************************************************************************/

--- a/include/wx_huff_dd_naive.hpp
+++ b/include/wx_huff_dd_naive.hpp
@@ -13,6 +13,8 @@
 #include "huffman/huff_dd.hpp"
 
 struct huff_naive_disp {
+  static constexpr bool needs_second_text_allocation = false;
+
   template <typename AlphabetType, typename ContextType, typename HuffCodes>
   static void calc_huff(AlphabetType const* text,
                         uint64_t const size,

--- a/include/wx_huff_dd_pc.hpp
+++ b/include/wx_huff_dd_pc.hpp
@@ -13,6 +13,8 @@
 #include "huffman/huff_dd.hpp"
 
 struct huff_pc_disp {
+  static constexpr bool needs_second_text_allocation = false;
+
   template <typename AlphabetType, typename ContextType, typename HuffCodes>
   static void calc_huff(AlphabetType const* text,
                         uint64_t const size,

--- a/include/wx_huff_dd_pc.hpp
+++ b/include/wx_huff_dd_pc.hpp
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * include/wx_huff_dd_pc.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include "huffman/huff_pc.hpp"
+#include "huffman/huff_dd.hpp"
+
+struct huff_pc_disp {
+  template <typename AlphabetType, typename ContextType, typename HuffCodes>
+  static void calc_huff(AlphabetType const* text,
+                        uint64_t const size,
+                        uint64_t const levels,
+                        HuffCodes const& codes,
+                        ContextType& ctx)
+  {
+    huff_pc(text, size, levels, codes, ctx);
+  }
+};
+
+template <typename AlphabetType, bool is_tree_>
+using wx_huff_dd_pc = huff_dd<huff_pc_disp, AlphabetType, is_tree_>;
+
+/******************************************************************************/

--- a/include/wx_huff_dd_ps.hpp
+++ b/include/wx_huff_dd_ps.hpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * include/wx_huff_dd_ps.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include "huffman/huff_ps.hpp"
+#include "huffman/huff_dd.hpp"
+
+struct huff_ps_disp {
+  static constexpr bool needs_second_text_allocation = true;
+
+  template <typename AlphabetType, typename ContextType, typename HuffCodes>
+  static void calc_huff(AlphabetType const* text,
+                        uint64_t const size,
+                        uint64_t const levels,
+                        HuffCodes const& codes,
+                        ContextType& ctx,
+                        AlphabetType* const sorted_text,
+                        std::vector<uint64_t> const& level_sizes)
+  {
+    huff_ps(text, size, levels, codes, ctx, sorted_text, level_sizes);
+  }
+};
+
+template <typename AlphabetType, bool is_tree_>
+using wx_huff_dd_ps = huff_dd<huff_ps_disp, AlphabetType, is_tree_>;
+
+/******************************************************************************/

--- a/include/wx_huff_naive.hpp
+++ b/include/wx_huff_naive.hpp
@@ -16,6 +16,8 @@
 #include "huffman/huff_bit_vectors.hpp"
 #include "huffman/huff_codes.hpp"
 #include "huffman/huff_level_sizes_builder.hpp"
+#include "huffman/ctx_huff_all_levels.hpp"
+#include "huffman/huff_naive.hpp"
 
 template <typename AlphabetType, bool is_tree_>
 class wx_huff_naive {
@@ -25,6 +27,9 @@ public:
   static constexpr bool    is_tree     = is_tree_;
   static constexpr uint8_t word_width  = sizeof(AlphabetType);
   static constexpr bool    is_huffman_shaped = true;
+
+  // TODO: change to single level
+  using ctx_t = ctx_huff_all_levels<is_tree>;
 
   static wavelet_structure compute(AlphabetType const* const text,
     const uint64_t size, const uint64_t /*levels*/) {
@@ -44,90 +49,14 @@ public:
       }
     }
 
-    auto bv = huff_bit_vectors(levels, level_sizes);
-    auto zeros = std::vector<size_t>();
+    const auto rho = rho_dispatch<is_tree>::create(levels);
+    auto ctx = ctx_t(level_sizes, levels, rho);
 
-    if constexpr (!is_tree) {
-      zeros = std::vector<size_t>(levels, 0);
-    }
+    huff_naive(text, size, levels, codes, ctx);
 
-    std::vector<AlphabetType> local_text(size);
-    for(size_t i = 0; i < size; i++) {
-      local_text[i] = text[i];
-    }
+    auto& bv = ctx.bv();
+    auto& zeros = ctx.zeros();
 
-    // Construct each level top-down
-    for (uint64_t level = 0; level < levels; ++level) {
-      std::vector<AlphabetType> text0;
-      std::vector<AlphabetType> text1;
-
-      // Insert the level-th MSB in the bit vector of the level (in text order)
-      uint32_t cur_pos = 0;
-      // Eat prefix in whole 64bit word chunks.
-      // Modification of local_text ensures its only as long as the level.
-      for (; cur_pos + 64 <= local_text.size(); cur_pos += 64) {
-        uint64_t word = 0ULL;
-        for (uint32_t i = 0; i < 64; ++i) {
-          const code_pair cp = codes.encode_symbol(local_text[cur_pos + i]);
-          word <<= 1;
-          word |= cp[level];
-          if constexpr (!is_tree) {
-            if (cp.code_length > level + 1) {
-              if (cp[level]) { text1.emplace_back(local_text[cur_pos + i]); }
-              else { text0.emplace_back(local_text[cur_pos + i]); }
-            }
-          }
-        }
-        if constexpr (!is_tree) {
-          zeros[level] += __builtin_popcountll(~word);
-        }
-        bv[level][cur_pos >> 6] = word;
-      }
-
-      // if there are remaining odd bits...
-      if (local_text.size() & 63ULL) {
-        uint64_t word = 0ULL;
-        for (uint32_t i = 0; i < local_text.size() - cur_pos; ++i) {
-          const code_pair cp = codes.encode_symbol(local_text[cur_pos + i]);
-          word <<= 1;
-          word |= cp[level];
-          if constexpr (!is_tree) {
-            if (cp.code_length > level + 1) {
-              if (cp[level]) { text1.emplace_back(local_text[cur_pos + i]); }
-              else { text0.emplace_back(local_text[cur_pos + i]); }
-            }
-          }
-        }
-        word <<= (64 - (local_text.size() & 63ULL));
-        bv[level][local_text.size() >> 6] = word;
-        if constexpr (!is_tree) {
-          zeros[level] +=
-            (local_text.size() & 63ULL) - __builtin_popcountll(word);
-        }
-      }
-
-      if constexpr (is_tree) {
-        std::vector<std::vector<AlphabetType>> buckets(1ULL << (level + 1));
-
-        for (uint64_t i = 0; i < local_text.size(); ++i) {
-          const AlphabetType cur_symbol = local_text[i];
-          if (codes.code_length(cur_symbol) > level + 1) {
-            // prefix gets the prefix bits of the codeword
-            buckets[codes.encode_symbol(cur_symbol).prefix(level + 1)]
-              .emplace_back(cur_symbol);
-          }
-        }
-
-        for (uint64_t i = 1; i < buckets.size(); ++i) {
-          std::move(buckets[i].begin(), buckets[i].end(),
-            std::back_inserter(buckets[0]));
-        }
-        local_text.swap(buckets[0]);
-      } else /*if constexpr (!is_tree)*/ {
-        std::move(text1.begin(), text1.end(), std::back_inserter(text0));
-        local_text = std::move(text0);
-      }
-    }
     if constexpr (is_tree) {
       return wavelet_structure_tree_huffman<AlphabetType>(
         std::move(bv), std::move(codes));

--- a/include/wx_huff_pc.hpp
+++ b/include/wx_huff_pc.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * include/wx_huff_pc.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstring>
+
+#include "construction/wavelet_structure.hpp"
+
+#include "huffman/huff_bit_vectors.hpp"
+#include "huffman/huff_codes.hpp"
+#include "huffman/huff_level_sizes_builder.hpp"
+#include "huffman/ctx_huff_all_levels.hpp"
+#include "huffman/huff_pc.hpp"
+
+template <typename AlphabetType, bool is_tree_>
+class wx_huff_pc {
+
+public:
+  static constexpr bool    is_parallel = false;
+  static constexpr bool    is_tree     = is_tree_;
+  static constexpr uint8_t word_width  = sizeof(AlphabetType);
+  static constexpr bool    is_huffman_shaped = true;
+
+  // TODO: change to single level
+  using ctx_t = ctx_huff_all_levels<is_tree>;
+
+  static wavelet_structure compute(AlphabetType const* const text,
+    const uint64_t size, const uint64_t /*levels*/) {
+
+    histogram<AlphabetType> hist { text, size };
+    level_sizes_builder<AlphabetType> builder { std::move(hist) };
+    canonical_huff_codes<AlphabetType, is_tree> codes(builder);
+
+    auto const& level_sizes = builder.level_sizes();
+    uint64_t const levels = builder.levels();
+
+    if(size == 0) {
+      if constexpr (is_tree) {
+        return wavelet_structure_tree_huffman<AlphabetType>(std::move(codes));
+      } else {
+        return wavelet_structure_matrix_huffman<AlphabetType>(std::move(codes));
+      }
+    }
+
+    const auto rho = rho_dispatch<is_tree>::create(levels);
+    auto ctx = ctx_t(level_sizes, levels, rho);
+
+    huff_pc(text, size, levels, codes, ctx);
+
+    auto& bv = ctx.bv();
+    auto& zeros = ctx.zeros();
+
+    if constexpr (is_tree) {
+      return wavelet_structure_tree_huffman<AlphabetType>(
+        std::move(bv), std::move(codes));
+    } else /*if constexpr (!is_tree)*/ {
+      return wavelet_structure_matrix_huffman<AlphabetType>(
+        std::move(bv), std::move(zeros), std::move(codes));
+    }
+  }
+}; // class wx_huff_naive
+
+/******************************************************************************/

--- a/include/wx_huff_ps.hpp
+++ b/include/wx_huff_ps.hpp
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * include/wx_huff_ps.hpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstring>
+
+#include "construction/wavelet_structure.hpp"
+
+#include "huffman/huff_bit_vectors.hpp"
+#include "huffman/huff_codes.hpp"
+#include "huffman/huff_level_sizes_builder.hpp"
+#include "huffman/ctx_huff_all_levels.hpp"
+#include "huffman/huff_ps.hpp"
+
+template <typename AlphabetType, bool is_tree_>
+class wx_huff_ps {
+
+public:
+  static constexpr bool    is_parallel = false;
+  static constexpr bool    is_tree     = is_tree_;
+  static constexpr uint8_t word_width  = sizeof(AlphabetType);
+  static constexpr bool    is_huffman_shaped = true;
+
+  // TODO: change to single level
+  using ctx_t = ctx_huff_all_levels<is_tree>;
+
+  static wavelet_structure compute(AlphabetType const* const text,
+    const uint64_t size, const uint64_t /*levels*/) {
+
+    histogram<AlphabetType> hist { text, size };
+    level_sizes_builder<AlphabetType> builder { std::move(hist) };
+    canonical_huff_codes<AlphabetType, is_tree> codes(builder);
+
+    auto const& level_sizes = builder.level_sizes();
+    uint64_t const levels = builder.levels();
+
+    if(size == 0) {
+      if constexpr (is_tree) {
+        return wavelet_structure_tree_huffman<AlphabetType>(std::move(codes));
+      } else {
+        return wavelet_structure_matrix_huffman<AlphabetType>(std::move(codes));
+      }
+    }
+
+    const auto rho = rho_dispatch<is_tree>::create(levels);
+    auto ctx = ctx_t(level_sizes, levels, rho);
+
+    {
+      auto sorted_text = std::vector<AlphabetType>(size);
+      huff_ps(text, size, levels, codes, ctx, sorted_text.data(), level_sizes);
+    }
+
+    auto& bv = ctx.bv();
+    auto& zeros = ctx.zeros();
+
+    if constexpr (is_tree) {
+      return wavelet_structure_tree_huffman<AlphabetType>(
+        std::move(bv), std::move(codes));
+    } else /*if constexpr (!is_tree)*/ {
+      return wavelet_structure_matrix_huffman<AlphabetType>(
+        std::move(bv), std::move(zeros), std::move(codes));
+    }
+  }
+}; // class wx_huff_naive
+
+/******************************************************************************/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(INTERNAL_SRCS
 
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_naive.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_naive.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_pc.cpp
 )
 
 set(INTERNAL_LIBS rt dl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,11 @@ set(INTERNAL_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/register/parallel_prefix_sorting.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/sequential_prefix_counting.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/sequential_prefix_counting_single_scan.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/register/sequential_prefix_sorting.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/sequential_prefix_sorting.cpp
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_naive.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_naive.cpp
+)
 
 set(INTERNAL_LIBS rt dl)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(INTERNAL_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_naive.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_pc.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_pc.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_ps.cpp
 )
 
 set(INTERNAL_LIBS rt dl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(INTERNAL_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_pc.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_pc.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_ps.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_ps.cpp
 )
 
 set(INTERNAL_LIBS rt dl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(INTERNAL_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_naive.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_naive.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_pc.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/register/huff_dd_pc.cpp
 )
 
 set(INTERNAL_LIBS rt dl)

--- a/src/register/huff_dd_naive.cpp
+++ b/src/register/huff_dd_naive.cpp
@@ -1,7 +1,8 @@
 /*******************************************************************************
- * src/register/dd_prefix_sorting.cpp
+ * src/register/huff_dd_naive.cpp
  *
  * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
  *
  * All rights reserved. Published under the BSD-2 license in the LICENSE file.
  ******************************************************************************/

--- a/src/register/huff_dd_naive.cpp
+++ b/src/register/huff_dd_naive.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * src/register/dd_prefix_sorting.cpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include "wx_huff_dd_naive.hpp"
+#include "benchmark/algorithm.hpp"
+
+using wm_huff_dd_naive_8 = wx_huff_dd_naive<uint8_t, false>;
+using wm_huff_dd_naive_16 = wx_huff_dd_naive<uint16_t, false>;
+using wm_huff_dd_naive_32 = wx_huff_dd_naive<uint32_t, false>;
+
+CONSTRUCTION_REGISTER("wm_huff_dd_naive",
+  "Parallel wavelet matrix construction with 8-bit alphabet "
+  "(using domain decomposition and the naive algorithm).", wm_huff_dd_naive_8)
+CONSTRUCTION_REGISTER("wm_huff_dd_naive",
+  "Parallel wavelet matrix construction with 16-bit alphabet "
+  "(using domain decomposition and the naive algorithm).", wm_huff_dd_naive_16)
+CONSTRUCTION_REGISTER("wm_huff_dd_naive",
+  "Parallel wavelet matrix construction with 32-bit alphabet "
+  "(using domain decomposition and the naive algorithm).", wm_huff_dd_naive_32)
+
+using wt_huff_dd_naive_8 = wx_huff_dd_naive<uint8_t, true>;
+using wt_huff_dd_naive_16 = wx_huff_dd_naive<uint16_t, true>;
+using wt_huff_dd_naive_32 = wx_huff_dd_naive<uint32_t, true>;
+
+CONSTRUCTION_REGISTER("wt_huff_dd_naive",
+  "Parallel wavelet tree construction with 8-bit alphabet "
+  "(using domain decomposition and the naive algorithm).", wt_huff_dd_naive_8)
+CONSTRUCTION_REGISTER("wt_huff_dd_naive",
+  "Parallel wavelet tree construction with 16-bit alphabet "
+  "(using domain decomposition and the naive algorithm).", wt_huff_dd_naive_16)
+CONSTRUCTION_REGISTER("wt_huff_dd_naive",
+  "Parallel wavelet tree construction with 32-bit alphabet "
+  "(using domain decomposition and the naive algorithm).", wt_huff_dd_naive_32)
+
+/******************************************************************************/

--- a/src/register/huff_dd_pc.cpp
+++ b/src/register/huff_dd_pc.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * src/register/huff_dd_pc.cpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include "wx_huff_dd_pc.hpp"
+#include "benchmark/algorithm.hpp"
+
+using wm_huff_dd_pc_8 = wx_huff_dd_pc<uint8_t, false>;
+using wm_huff_dd_pc_16 = wx_huff_dd_pc<uint16_t, false>;
+using wm_huff_dd_pc_32 = wx_huff_dd_pc<uint32_t, false>;
+
+CONSTRUCTION_REGISTER("wm_huff_dd_pc",
+  "Parallel wavelet matrix construction with 8-bit alphabet "
+  "(using domain decomposition and the pc algorithm).", wm_huff_dd_pc_8)
+CONSTRUCTION_REGISTER("wm_huff_dd_pc",
+  "Parallel wavelet matrix construction with 16-bit alphabet "
+  "(using domain decomposition and the pc algorithm).", wm_huff_dd_pc_16)
+CONSTRUCTION_REGISTER("wm_huff_dd_pc",
+  "Parallel wavelet matrix construction with 32-bit alphabet "
+  "(using domain decomposition and the pc algorithm).", wm_huff_dd_pc_32)
+
+using wt_huff_dd_pc_8 = wx_huff_dd_pc<uint8_t, true>;
+using wt_huff_dd_pc_16 = wx_huff_dd_pc<uint16_t, true>;
+using wt_huff_dd_pc_32 = wx_huff_dd_pc<uint32_t, true>;
+
+CONSTRUCTION_REGISTER("wt_huff_dd_pc",
+  "Parallel wavelet tree construction with 8-bit alphabet "
+  "(using domain decomposition and the pc algorithm).", wt_huff_dd_pc_8)
+CONSTRUCTION_REGISTER("wt_huff_dd_pc",
+  "Parallel wavelet tree construction with 16-bit alphabet "
+  "(using domain decomposition and the pc algorithm).", wt_huff_dd_pc_16)
+CONSTRUCTION_REGISTER("wt_huff_dd_pc",
+  "Parallel wavelet tree construction with 32-bit alphabet "
+  "(using domain decomposition and the pc algorithm).", wt_huff_dd_pc_32)
+
+/******************************************************************************/

--- a/src/register/huff_dd_ps.cpp
+++ b/src/register/huff_dd_ps.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * src/register/huff_dd_ps.cpp
+ *
+ * Copyright (C) 2017 Florian Kurpicz <florian.kurpicz@tu-dortmund.de>
+ * Copyright (C) 2017 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include "wx_huff_dd_ps.hpp"
+#include "benchmark/algorithm.hpp"
+
+using wm_huff_dd_ps_8 = wx_huff_dd_ps<uint8_t, false>;
+using wm_huff_dd_ps_16 = wx_huff_dd_ps<uint16_t, false>;
+using wm_huff_dd_ps_32 = wx_huff_dd_ps<uint32_t, false>;
+
+CONSTRUCTION_REGISTER("wm_huff_dd_ps",
+  "Parallel wavelet matrix construction with 8-bit alphabet "
+  "(using domain decomposition and the ps algorithm).", wm_huff_dd_ps_8)
+CONSTRUCTION_REGISTER("wm_huff_dd_ps",
+  "Parallel wavelet matrix construction with 16-bit alphabet "
+  "(using domain decomposition and the ps algorithm).", wm_huff_dd_ps_16)
+CONSTRUCTION_REGISTER("wm_huff_dd_ps",
+  "Parallel wavelet matrix construction with 32-bit alphabet "
+  "(using domain decomposition and the ps algorithm).", wm_huff_dd_ps_32)
+
+using wt_huff_dd_ps_8 = wx_huff_dd_ps<uint8_t, true>;
+using wt_huff_dd_ps_16 = wx_huff_dd_ps<uint16_t, true>;
+using wt_huff_dd_ps_32 = wx_huff_dd_ps<uint32_t, true>;
+
+CONSTRUCTION_REGISTER("wt_huff_dd_ps",
+  "Parallel wavelet tree construction with 8-bit alphabet "
+  "(using domain decomposition and the ps algorithm).", wt_huff_dd_ps_8)
+CONSTRUCTION_REGISTER("wt_huff_dd_ps",
+  "Parallel wavelet tree construction with 16-bit alphabet "
+  "(using domain decomposition and the ps algorithm).", wt_huff_dd_ps_16)
+CONSTRUCTION_REGISTER("wt_huff_dd_ps",
+  "Parallel wavelet tree construction with 32-bit alphabet "
+  "(using domain decomposition and the ps algorithm).", wt_huff_dd_ps_32)
+
+/******************************************************************************/

--- a/src/register/huff_pc.cpp
+++ b/src/register/huff_pc.cpp
@@ -12,26 +12,26 @@
 using wm_huff_pc_8 = wx_huff_pc<uint8_t, false>;
 using wm_huff_pc_16 = wx_huff_pc<uint16_t, false>;
 using wm_huff_pc_32 = wx_huff_pc<uint32_t, false>;
-CONSTRUCTION_REGISTER("huff_wm_pc",
+CONSTRUCTION_REGISTER("wm_huff_pc",
   "Sequential Huffman-shaped wavelet matrix construction with 8-bit"
   " alphabet (using counting).", wm_huff_pc_8)
-CONSTRUCTION_REGISTER("huff_wm_pc",
+CONSTRUCTION_REGISTER("wm_huff_pc",
   "Sequential Huffman-shaped wavelet matrix construction with 16-bit"
   " alphabet (using counting).", wm_huff_pc_16)
-CONSTRUCTION_REGISTER("huff_wm_pc",
+CONSTRUCTION_REGISTER("wm_huff_pc",
   "Sequential Huffman-shaped wavelet matrix construction with 32-bit"
   " alphabet (using counting).", wm_huff_pc_32)
 
 using wt_huff_pc_8 = wx_huff_pc<uint8_t, true>;
 using wt_huff_pc_16 = wx_huff_pc<uint16_t, true>;
 using wt_huff_pc_32 = wx_huff_pc<uint32_t, true>;
-CONSTRUCTION_REGISTER("huff_wt_pc",
+CONSTRUCTION_REGISTER("wt_huff_pc",
   "Sequential Huffman-shaped wavelet tree construction with 8-bit"
   " alphabet (using counting).", wt_huff_pc_8)
-CONSTRUCTION_REGISTER("huff_wt_pc",
+CONSTRUCTION_REGISTER("wt_huff_pc",
   "Sequential Huffman-shaped wavelet tree construction with 16-bit"
   " alphabet (using counting).", wt_huff_pc_16)
-CONSTRUCTION_REGISTER("huff_wt_pc",
+CONSTRUCTION_REGISTER("wt_huff_pc",
   "Sequential Huffman-shaped wavelet tree construction with 32-bit"
   " alphabet (using counting).", wt_huff_pc_32)
 

--- a/src/register/huff_pc.cpp
+++ b/src/register/huff_pc.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * src/register/huff_pc.cpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include "benchmark/algorithm.hpp"
+#include "wx_huff_pc.hpp"
+
+using wm_huff_pc_8 = wx_huff_pc<uint8_t, false>;
+using wm_huff_pc_16 = wx_huff_pc<uint16_t, false>;
+using wm_huff_pc_32 = wx_huff_pc<uint32_t, false>;
+CONSTRUCTION_REGISTER("huff_wm_pc",
+  "Sequential Huffman-shaped wavelet matrix construction with 8-bit"
+  " alphabet (using counting).", wm_huff_pc_8)
+CONSTRUCTION_REGISTER("huff_wm_pc",
+  "Sequential Huffman-shaped wavelet matrix construction with 16-bit"
+  " alphabet (using counting).", wm_huff_pc_16)
+CONSTRUCTION_REGISTER("huff_wm_pc",
+  "Sequential Huffman-shaped wavelet matrix construction with 32-bit"
+  " alphabet (using counting).", wm_huff_pc_32)
+
+using wt_huff_pc_8 = wx_huff_pc<uint8_t, true>;
+using wt_huff_pc_16 = wx_huff_pc<uint16_t, true>;
+using wt_huff_pc_32 = wx_huff_pc<uint32_t, true>;
+CONSTRUCTION_REGISTER("huff_wt_pc",
+  "Sequential Huffman-shaped wavelet tree construction with 8-bit"
+  " alphabet (using counting).", wt_huff_pc_8)
+CONSTRUCTION_REGISTER("huff_wt_pc",
+  "Sequential Huffman-shaped wavelet tree construction with 16-bit"
+  " alphabet (using counting).", wt_huff_pc_16)
+CONSTRUCTION_REGISTER("huff_wt_pc",
+  "Sequential Huffman-shaped wavelet tree construction with 32-bit"
+  " alphabet (using counting).", wt_huff_pc_32)
+
+/******************************************************************************/

--- a/src/register/huff_ps.cpp
+++ b/src/register/huff_ps.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * src/register/huff_ps.cpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include "benchmark/algorithm.hpp"
+#include "wx_huff_ps.hpp"
+
+using wm_huff_ps_8 = wx_huff_ps<uint8_t, false>;
+using wm_huff_ps_16 = wx_huff_ps<uint16_t, false>;
+using wm_huff_ps_32 = wx_huff_ps<uint32_t, false>;
+CONSTRUCTION_REGISTER("huff_wm_ps",
+  "Sequential Huffman-shaped wavelet matrix construction with 8-bit"
+  " alphabet (using sorting).", wm_huff_ps_8)
+CONSTRUCTION_REGISTER("huff_wm_ps",
+  "Sequential Huffman-shaped wavelet matrix construction with 16-bit"
+  " alphabet (using sorting).", wm_huff_ps_16)
+CONSTRUCTION_REGISTER("huff_wm_ps",
+  "Sequential Huffman-shaped wavelet matrix construction with 32-bit"
+  " alphabet (using sorting).", wm_huff_ps_32)
+
+using wt_huff_ps_8 = wx_huff_ps<uint8_t, true>;
+using wt_huff_ps_16 = wx_huff_ps<uint16_t, true>;
+using wt_huff_ps_32 = wx_huff_ps<uint32_t, true>;
+CONSTRUCTION_REGISTER("huff_wt_ps",
+  "Sequential Huffman-shaped wavelet tree construction with 8-bit"
+  " alphabet (using sorting).", wt_huff_ps_8)
+CONSTRUCTION_REGISTER("huff_wt_ps",
+  "Sequential Huffman-shaped wavelet tree construction with 16-bit"
+  " alphabet (using sorting).", wt_huff_ps_16)
+CONSTRUCTION_REGISTER("huff_wt_ps",
+  "Sequential Huffman-shaped wavelet tree construction with 32-bit"
+  " alphabet (using sorting).", wt_huff_ps_32)
+
+/******************************************************************************/

--- a/src/register/huff_ps.cpp
+++ b/src/register/huff_ps.cpp
@@ -12,26 +12,26 @@
 using wm_huff_ps_8 = wx_huff_ps<uint8_t, false>;
 using wm_huff_ps_16 = wx_huff_ps<uint16_t, false>;
 using wm_huff_ps_32 = wx_huff_ps<uint32_t, false>;
-CONSTRUCTION_REGISTER("huff_wm_ps",
+CONSTRUCTION_REGISTER("wm_huff_ps",
   "Sequential Huffman-shaped wavelet matrix construction with 8-bit"
   " alphabet (using sorting).", wm_huff_ps_8)
-CONSTRUCTION_REGISTER("huff_wm_ps",
+CONSTRUCTION_REGISTER("wm_huff_ps",
   "Sequential Huffman-shaped wavelet matrix construction with 16-bit"
   " alphabet (using sorting).", wm_huff_ps_16)
-CONSTRUCTION_REGISTER("huff_wm_ps",
+CONSTRUCTION_REGISTER("wm_huff_ps",
   "Sequential Huffman-shaped wavelet matrix construction with 32-bit"
   " alphabet (using sorting).", wm_huff_ps_32)
 
 using wt_huff_ps_8 = wx_huff_ps<uint8_t, true>;
 using wt_huff_ps_16 = wx_huff_ps<uint16_t, true>;
 using wt_huff_ps_32 = wx_huff_ps<uint32_t, true>;
-CONSTRUCTION_REGISTER("huff_wt_ps",
+CONSTRUCTION_REGISTER("wt_huff_ps",
   "Sequential Huffman-shaped wavelet tree construction with 8-bit"
   " alphabet (using sorting).", wt_huff_ps_8)
-CONSTRUCTION_REGISTER("huff_wt_ps",
+CONSTRUCTION_REGISTER("wt_huff_ps",
   "Sequential Huffman-shaped wavelet tree construction with 16-bit"
   " alphabet (using sorting).", wt_huff_ps_16)
-CONSTRUCTION_REGISTER("huff_wt_ps",
+CONSTRUCTION_REGISTER("wt_huff_ps",
   "Sequential Huffman-shaped wavelet tree construction with 32-bit"
   " alphabet (using sorting).", wt_huff_ps_32)
 

--- a/test/util/testsuite.cmake
+++ b/test/util/testsuite.cmake
@@ -37,9 +37,11 @@ macro(generic_run_test test_target test_file
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_counting.cpp
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_counting_single_scan.cpp
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_sorting.cpp
+      ${PROJECT_SOURCE_DIR}/src/register/huff_naive.cpp
+      ${PROJECT_SOURCE_DIR}/src/register/huff_dd_naive.cpp
       )
   else()
-    unset(CONSTRUCTION_ALGORITHMS) 
+    unset(CONSTRUCTION_ALGORITHMS)
   endif()
 
   add_executable(${test_target}_testrunner

--- a/test/util/testsuite.cmake
+++ b/test/util/testsuite.cmake
@@ -37,10 +37,12 @@ macro(generic_run_test test_target test_file
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_counting.cpp
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_counting_single_scan.cpp
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_sorting.cpp
+
       ${PROJECT_SOURCE_DIR}/src/register/huff_naive.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_dd_naive.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_pc.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_dd_pc.cpp
+      ${PROJECT_SOURCE_DIR}/src/register/huff_ps.cpp
       )
   else()
     unset(CONSTRUCTION_ALGORITHMS)

--- a/test/util/testsuite.cmake
+++ b/test/util/testsuite.cmake
@@ -39,6 +39,7 @@ macro(generic_run_test test_target test_file
       ${PROJECT_SOURCE_DIR}/src/register/sequential_prefix_sorting.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_naive.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_dd_naive.cpp
+      ${PROJECT_SOURCE_DIR}/src/register/huff_pc.cpp
       )
   else()
     unset(CONSTRUCTION_ALGORITHMS)

--- a/test/util/testsuite.cmake
+++ b/test/util/testsuite.cmake
@@ -43,6 +43,7 @@ macro(generic_run_test test_target test_file
       ${PROJECT_SOURCE_DIR}/src/register/huff_pc.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_dd_pc.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_ps.cpp
+      ${PROJECT_SOURCE_DIR}/src/register/huff_dd_ps.cpp
       )
   else()
     unset(CONSTRUCTION_ALGORITHMS)

--- a/test/util/testsuite.cmake
+++ b/test/util/testsuite.cmake
@@ -40,6 +40,7 @@ macro(generic_run_test test_target test_file
       ${PROJECT_SOURCE_DIR}/src/register/huff_naive.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_dd_naive.cpp
       ${PROJECT_SOURCE_DIR}/src/register/huff_pc.cpp
+      ${PROJECT_SOURCE_DIR}/src/register/huff_dd_pc.cpp
       )
   else()
     unset(CONSTRUCTION_ALGORITHMS)


### PR DESCRIPTION
Expanded list:

- `huff_pc`
- `huff_ps`
- `huff_dd_pc`
- `huff_dd_ps`
- `huff_dd_naive`

Also moved impl in `wx_huff_naive` into a reusable `huff_naive.hpp`

# __TODO__

- [ ] The non-dd impls currently use the same ctx as the dd ones. This means arrays for all levels of hist are allocated, rather than just one. Either change to same system as for the non-huffman code, or simplify all impls by always allocating all arrays, since it will only grow memroy consumption by `O(log n)`.
- [ ] Related to above, the impl of pc and ps calculate top-down, rather than button-up since it simplifies the code. Check if this needs to be changed.

