### PR TITLE
Factor out common functions

### DIFF
--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -74,4 +74,5 @@ inline void bottom_up_compute_hist_and_borders_and_optional_zeros(
       ctx.zeros()[level - 1] = ctx.borders(level, 1);
     }
   }
+  ctx.hist(0, 0) = size;
 }

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -52,6 +52,7 @@ inline void scan_text_compute_first_level_bv_and_last_level_hist(
 
 template<typename ctx_t>
 inline void bottom_up_compute_hist_and_borders_and_optional_zeros(
+  uint64_t const size,
   uint64_t const levels,
   ctx_t& ctx
 ) {

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -77,3 +77,38 @@ inline void bottom_up_compute_hist_and_borders_and_optional_zeros(
   }
   ctx.hist(0, 0) = size;
 }
+
+template<typename ctx_t>
+inline void compute_borders_and_optional_zeros(
+    uint64_t level,
+    uint64_t blocks,
+    ctx_t& ctx
+) {
+    auto& borders = ctx.borders();
+
+    // Compute the starting positions of characters with respect to their
+    // bit prefixes and the bit-reversal permutation
+    borders[0] = 0;
+    for (uint64_t i = 1; i < blocks; ++i) {
+      auto const prev_block = ctx.rho(level, i - 1);
+      auto const this_block = ctx.rho(level, i);
+
+      borders[this_block] = borders[prev_block] + ctx.hist(level, prev_block);
+      // NB: The above calulcation produces _wrong_ border offsets
+      // for huffman codes that are one-shorter than the current level.
+      //
+      // Since those codes will not be used in the loop below, this does not
+      // produce wrong or out-of-bound accesses.
+
+      if (ctx_t::compute_rho)  {
+        ctx.set_rho(level - 1, i - 1, prev_block >> 1);
+      }
+    }
+
+    if (ctx_t::compute_zeros) {
+      // If we compute zeros, we are working on a WM instead of a WT.
+      // For a WM, borders is permuted with rho such that
+      // borders[1] contains the position of the first 1-bit block.
+      ctx.zeros()[level - 1] = borders[1];
+    }
+}

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -63,3 +63,30 @@ inline void bottom_up_compute_hist_and_borders_and_optional_zeros(
     }
   }
 }
+
+template<typename level_bv_t, typename loop_body_t>
+inline void write_bits_wordwise(uint64_t start,
+                                uint64_t size,
+                                level_bv_t const& level_bv,
+                                loop_body_t body) {
+    uint64_t cur_pos = start;
+    for (; cur_pos + 64 <= size; cur_pos += 64) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < 64; ++i) {
+        uint64_t const bit = body(cur_pos + i);
+        word <<= 1;
+        word |= bit;
+      }
+      level_bv[cur_pos >> 6] = word;
+    }
+    if (size & 63ULL) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = cur_pos; i < size; ++i) {
+        uint64_t const bit = body(i);
+        word <<= 1;
+        word |= bit;
+      }
+      word <<= (64 - (size & 63ULL));
+      level_bv[size >> 6] = word;
+    }
+}

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * include/huffman/huff_pc.hpp
+ * include/construction/building_blocks.hpp
  *
  * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
  *

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * include/huffman/huff_pc.hpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+template<typename text_t, typename ctx_t, typename bv_t>
+inline void scan_text_compute_first_level_bv_and_last_level_hist(
+  text_t const& text,
+  size_t const size,
+  uint64_t const levels,
+  bv_t& bv,
+  ctx_t& ctx
+) {
+  uint64_t cur_pos = 0;
+  for (; cur_pos + 64 <= size; cur_pos += 64) {
+    uint64_t word = 0ULL;
+    for (uint64_t i = 0; i < 64; ++i) {
+      ++ctx.hist(levels, text[cur_pos + i]);
+      word <<= 1;
+      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
+    }
+    bv[0][cur_pos >> 6] = word;
+  }
+  if (size & 63ULL) {
+    uint64_t word = 0ULL;
+    for (uint64_t i = 0; i < size - cur_pos; ++i) {
+      ++ctx.hist(levels, text[cur_pos + i]);
+      word <<= 1;
+      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
+    }
+    word <<= (64 - (size & 63ULL));
+    bv[0][size >> 6] = word;
+  }
+}

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -79,7 +79,7 @@ inline void bottom_up_compute_hist_and_borders_and_optional_zeros(
 }
 
 template<typename ctx_t>
-inline void compute_borders_and_optional_zeros(
+inline void compute_borders_and_optional_zeros_and_optional_rho(
     uint64_t level,
     uint64_t blocks,
     ctx_t& ctx

--- a/include/construction/building_blocks.hpp
+++ b/include/construction/building_blocks.hpp
@@ -28,10 +28,10 @@ inline void scan_text_compute_first_level_bv_and_last_level_hist(
   }
   if (size & 63ULL) {
     uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < size - cur_pos; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
+    for (uint64_t i = cur_pos; i < size; ++i) {
+      ++ctx.hist(levels, text[i]);
       word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
+      word |= ((text[i] >> (levels - 1)) & 1ULL);
     }
     word <<= (64 - (size & 63ULL));
     bv[0][size >> 6] = word;

--- a/include/construction/ctx_compute_borders.hpp
+++ b/include/construction/ctx_compute_borders.hpp
@@ -30,26 +30,6 @@ public:
   static bool constexpr compute_zeros = !is_tree;
   static bool constexpr compute_rho = false;
 
-  void fill_borders() {
-    for (uint64_t level = levels_ - 1; level > 0; --level) {
-      for (uint64_t pos = 0; pos < hist_size(level); ++pos) {
-        hist_[level][pos] = hist_[level + 1][pos << 1] +
-          hist_[level + 1][(pos << 1) + 1];
-      }
-
-      borders_[level][0] = 0;
-      for (uint64_t pos = 1; pos < hist_size(level); ++pos) {
-        auto const prev_rho = rho(level, pos - 1);
-
-        borders_[level][rho(level, pos)] =
-          borders_[level][prev_rho] + hist_[level][prev_rho];
-      }
-
-      // The number of 0s is the position of the first 1 in the previous level
-      if constexpr (compute_zeros) { zeros_[level - 1] = borders_[level][1]; }
-    }
-  }
-
   inline uint64_t hist_size(uint64_t const level) {
     return 1ULL << level;
   }

--- a/include/construction/pc.hpp
+++ b/include/construction/pc.hpp
@@ -46,22 +46,7 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    borders[0] = 0;
-    for (uint64_t i = 1; i < cur_alphabet_size; ++i) {
-      auto const prev_rho = ctx.rho(level, i - 1);
-
-      borders[ctx.rho(level, i)] =
-        borders[prev_rho] + ctx.hist(level, prev_rho);
-
-      if (ContextType::compute_rho)  {
-        ctx.set_rho(level - 1, i - 1, prev_rho >> 1);
-      }
-    }
-
-    // The number of 0s is the position of the first 1 in the previous level
-    if (ContextType::compute_zeros) {
-      zeros[level - 1] = borders[1];
-    }
+    compute_borders_and_optional_zeros(level, cur_alphabet_size, ctx);
 
     // Now we insert the bits with respect to their bit prefixes
     for (uint64_t i = 0; i < size; ++i) {

--- a/include/construction/pc.hpp
+++ b/include/construction/pc.hpp
@@ -13,7 +13,7 @@
 template <typename AlphabetType, typename ContextType>
 void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
   ContextType& ctx) {
-  uint64_t cur_max_char = (1 << levels);
+  uint64_t cur_alphabet_size = (1 << levels);
 
   auto& zeros = ctx.zeros();
   auto& borders = ctx.borders();
@@ -25,7 +25,7 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
 
   // The number of 0s at the last level is the number of "even" characters
   if (ContextType::compute_zeros) {
-    for (uint64_t i = 0; i < cur_max_char; i += 2) {
+    for (uint64_t i = 0; i < cur_alphabet_size; i += 2) {
       zeros[levels - 1] += ctx.hist(levels, i);
     }
   }
@@ -37,8 +37,8 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
 
     // Update the maximum value of a feasible a bit prefix and update the
     // histogram of the bit prefixes
-    cur_max_char >>= 1;
-    for (uint64_t i = 0; i < cur_max_char; ++i) {
+    cur_alphabet_size >>= 1;
+    for (uint64_t i = 0; i < cur_alphabet_size; ++i) {
       ctx.hist(level, i)
         = ctx.hist(level + 1, i << 1)
         + ctx.hist(level + 1, (i << 1) + 1);
@@ -47,7 +47,7 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
     borders[0] = 0;
-    for (uint64_t i = 1; i < cur_max_char; ++i) {
+    for (uint64_t i = 1; i < cur_alphabet_size; ++i) {
       auto const prev_rho = ctx.rho(level, i - 1);
 
       borders[ctx.rho(level, i)] =

--- a/include/construction/pc.hpp
+++ b/include/construction/pc.hpp
@@ -20,8 +20,7 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
   auto& bv = ctx.bv();
 
   scan_text_compute_first_level_bv_and_last_level_hist(
-    text, size, levels, bv, ctx
-  );
+    text, size, levels, bv, ctx);
 
   // The number of 0s at the last level is the number of "even" characters
   if (ContextType::compute_zeros) {
@@ -46,7 +45,8 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    compute_borders_and_optional_zeros(level, cur_alphabet_size, ctx);
+    compute_borders_and_optional_zeros_and_optional_rho(
+      level, cur_alphabet_size, ctx);
 
     // Now we insert the bits with respect to their bit prefixes
     for (uint64_t i = 0; i < size; ++i) {

--- a/include/construction/pc.hpp
+++ b/include/construction/pc.hpp
@@ -88,9 +88,7 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
     }
   }
 
-  if (levels > 1) { // TODO check condition
-    ctx.hist(0, 0) = ctx.hist(1, 0) + ctx.hist(1, 1);
-  }
+  ctx.hist(0, 0) = size;
 }
 
 /******************************************************************************/

--- a/include/construction/pc.hpp
+++ b/include/construction/pc.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "construction/building_blocks.hpp"
+
 template <typename AlphabetType, typename ContextType>
 void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
   ContextType& ctx) {
@@ -17,28 +19,9 @@ void pc(AlphabetType const* text, const uint64_t size, const uint64_t levels,
   auto& borders = ctx.borders();
   auto& bv = ctx.bv();
 
-  // While initializing the histogram, we also compute the first level
-  uint64_t cur_pos = 0;
-  for (; cur_pos + 64 <= size; cur_pos += 64) {
-    uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < 64; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
-      word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
-    }
-    bv[0][cur_pos >> 6] = word;
-  }
-  if (size & 63ULL) {
-    uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < size - cur_pos; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
-      word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
-    }
-    word <<= (64 - (size & 63ULL));
-    bv[0][size >> 6] = word;
-  }
-
+  scan_text_compute_first_level_bv_and_last_level_hist(
+    text, size, levels, bv, ctx
+  );
 
   // The number of 0s at the last level is the number of "even" characters
   if (ContextType::compute_zeros) {

--- a/include/construction/pc_ss.hpp
+++ b/include/construction/pc_ss.hpp
@@ -20,7 +20,7 @@ void pc_ss(AlphabetType const* const text, uint64_t const size,
     text, size, levels, bv, ctx
   );
 
-  bottom_up_compute_hist_and_borders_and_optional_zeros(levels, ctx);
+  bottom_up_compute_hist_and_borders_and_optional_zeros(size, levels, ctx);
 
   for (uint64_t i = 0; i < size; ++i) {
     for (uint64_t level = levels - 1; level > 0; --level) {

--- a/include/construction/pc_ss.hpp
+++ b/include/construction/pc_ss.hpp
@@ -48,9 +48,7 @@ void pc_ss(AlphabetType const* const text, uint64_t const size,
     }
   }
 
-  if (levels > 1) { // TODO check condition
-    ctx.hist(0, 0) = ctx.hist(1, 0) + ctx.hist(1, 1);
-  }
+  ctx.hist(0, 0) = size;
 }
 
 /******************************************************************************/

--- a/include/construction/pc_ss.hpp
+++ b/include/construction/pc_ss.hpp
@@ -8,33 +8,17 @@
 
 #pragma once
 
+#include "construction/building_blocks.hpp"
+
 template <typename AlphabetType, typename ContextType>
 void pc_ss(AlphabetType const* const text, uint64_t const size,
   uint64_t const levels, ContextType& ctx) {
 
   auto& bv = ctx.bv();
 
-  // While initializing the histogram, we also compute the first level
-  uint64_t cur_pos = 0;
-  for (; cur_pos + 64 <= size; cur_pos += 64) {
-    uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < 64; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
-      word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
-    }
-    bv[0][cur_pos >> 6] = word;
-  }
-  if (size & 63ULL) {
-    uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < size - cur_pos; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
-      word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
-    }
-    word <<= (64 - (size & 63ULL));
-    bv[0][size >> 6] = word;
-  }
+  scan_text_compute_first_level_bv_and_last_level_hist(
+    text, size, levels, bv, ctx
+  );
 
   ctx.fill_borders();
 

--- a/include/construction/pc_ss.hpp
+++ b/include/construction/pc_ss.hpp
@@ -20,7 +20,7 @@ void pc_ss(AlphabetType const* const text, uint64_t const size,
     text, size, levels, bv, ctx
   );
 
-  ctx.fill_borders();
+  bottom_up_compute_hist_and_borders_and_optional_zeros(levels, ctx);
 
   for (uint64_t i = 0; i < size; ++i) {
     for (uint64_t level = levels - 1; level > 0; --level) {

--- a/include/construction/pc_ss.hpp
+++ b/include/construction/pc_ss.hpp
@@ -31,8 +31,6 @@ void pc_ss(AlphabetType const* const text, uint64_t const size,
         << (63ULL - (pos & 63ULL)));
     }
   }
-
-  ctx.hist(0, 0) = size;
 }
 
 /******************************************************************************/

--- a/include/construction/ps.hpp
+++ b/include/construction/ps.hpp
@@ -20,8 +20,7 @@ void ps(AlphabetType const* const text, uint64_t const size,
   auto& bv = ctx.bv();
 
   scan_text_compute_first_level_bv_and_last_level_hist(
-    text, size, levels, bv, ctx
-  );
+    text, size, levels, bv, ctx);
 
   // The number of 0s at the last level is the number of "even" characters
   if (ContextType::compute_zeros) {
@@ -43,7 +42,8 @@ void ps(AlphabetType const* const text, uint64_t const size,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    compute_borders_and_optional_zeros(level, cur_alphabet_size, ctx);
+    compute_borders_and_optional_zeros_and_optional_rho(
+      level, cur_alphabet_size, ctx);
 
     // Now we sort the text utilizing counting sort and the starting positions
     // that we have computed before

--- a/include/construction/ps.hpp
+++ b/include/construction/ps.hpp
@@ -70,24 +70,10 @@ void ps(AlphabetType const* const text, uint64_t const size,
     // Since we have sorted the text, we can simply scan it from left to right
     // and for the character at position $i$ we set the $i$-th bit in the
     // bit vector accordingly
-    uint64_t cur_pos = 0;
-    for (cur_pos = 0; cur_pos + 63 < size; cur_pos += 64) {
-      uint64_t word = 0ULL;
-      for (uint64_t i = 0; i < 64; ++i) {
-        word <<= 1;
-        word |= ((sorted_text[cur_pos + i] >> ((levels - 1) - level)) & 1ULL);
-      }
-      bv[level][cur_pos >> 6] = word;
-    }
-    if (size & 63ULL) {
-      uint64_t word = 0ULL;
-      for (uint64_t i = 0; i < size - cur_pos; ++i) {
-        word <<= 1;
-        word |= ((sorted_text[cur_pos + i] >> ((levels - 1) - level)) & 1ULL);
-      }
-      word <<= (64 - (size & 63ULL));
-      bv[level][size >> 6] = word;
-    }
+    write_bits_wordwise(0, size, bv[level], [&](uint64_t const i) {
+      uint64_t const bit = ((sorted_text[i] >> ((levels - 1) - level)) & 1ULL);
+      return bit;
+    });
   }
 
   ctx.hist(0, 0) = size;

--- a/include/construction/ps.hpp
+++ b/include/construction/ps.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "construction/building_blocks.hpp"
+
 template <typename AlphabetType, typename ContextType>
 void ps(AlphabetType const* const text, uint64_t const size,
   uint64_t const levels, ContextType& ctx, AlphabetType* const sorted_text) {
@@ -17,27 +19,9 @@ void ps(AlphabetType const* const text, uint64_t const size,
   auto& borders = ctx.borders();
   auto& bv = ctx.bv();
 
-  // While initializing the histogram, we also compute the first level
-  uint64_t cur_pos = 0;
-  for (; cur_pos + 64 <= size; cur_pos += 64) {
-    uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < 64; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
-      word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
-    }
-    bv[0][cur_pos >> 6] = word;
-  }
-  if (size & 63ULL) {
-    uint64_t word = 0ULL;
-    for (uint64_t i = 0; i < size - cur_pos; ++i) {
-      ++ctx.hist(levels, text[cur_pos + i]);
-      word <<= 1;
-      word |= ((text[cur_pos + i] >> (levels - 1)) & 1ULL);
-    }
-    word <<= (64 - (size & 63ULL));
-    bv[0][size >> 6] = word;
-  }
+  scan_text_compute_first_level_bv_and_last_level_hist(
+    text, size, levels, bv, ctx
+  );
 
   // The number of 0s at the last level is the number of "even" characters
   if (ContextType::compute_zeros) {
@@ -86,6 +70,7 @@ void ps(AlphabetType const* const text, uint64_t const size,
     // Since we have sorted the text, we can simply scan it from left to right
     // and for the character at position $i$ we set the $i$-th bit in the
     // bit vector accordingly
+    uint64_t cur_pos = 0;
     for (cur_pos = 0; cur_pos + 63 < size; cur_pos += 64) {
       uint64_t word = 0ULL;
       for (uint64_t i = 0; i < 64; ++i) {

--- a/include/construction/ps.hpp
+++ b/include/construction/ps.hpp
@@ -43,22 +43,7 @@ void ps(AlphabetType const* const text, uint64_t const size,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    borders[0] = 0;
-    for (uint64_t i = 1; i < cur_alphabet_size; ++i) {
-      auto const prev_rho = ctx.rho(level, i - 1);
-
-      borders[ctx.rho(level, i)] =
-        borders[prev_rho] + ctx.hist(level, prev_rho);
-
-      if (ContextType::compute_rho)  {
-        ctx.set_rho(level - 1, i - 1, prev_rho >> 1);
-      }
-    }
-
-    // The number of 0s is the position of the first 1 in the previous level
-    if (ContextType::compute_zeros) {
-      zeros[level - 1] = borders[1];
-    }
+    compute_borders_and_optional_zeros(level, cur_alphabet_size, ctx);
 
     // Now we sort the text utilizing counting sort and the starting positions
     // that we have computed before

--- a/include/construction/ps.hpp
+++ b/include/construction/ps.hpp
@@ -13,7 +13,7 @@
 template <typename AlphabetType, typename ContextType>
 void ps(AlphabetType const* const text, uint64_t const size,
   uint64_t const levels, ContextType& ctx, AlphabetType* const sorted_text) {
-  uint64_t cur_max_char = (1 << levels);
+  uint64_t cur_alphabet_size = (1 << levels);
 
   auto& zeros = ctx.zeros();
   auto& borders = ctx.borders();
@@ -25,7 +25,7 @@ void ps(AlphabetType const* const text, uint64_t const size,
 
   // The number of 0s at the last level is the number of "even" characters
   if (ContextType::compute_zeros) {
-    for (uint64_t i = 0; i < cur_max_char; i += 2) {
+    for (uint64_t i = 0; i < cur_alphabet_size; i += 2) {
       zeros[levels - 1] += ctx.hist(levels, i);
     }
   }
@@ -34,8 +34,8 @@ void ps(AlphabetType const* const text, uint64_t const size,
   for (uint64_t level = levels - 1; level > 0; --level) {
     // Update the maximum value of a feasible a bit prefix and update the
     // histogram of the bit prefixes
-    cur_max_char >>= 1;
-    for (uint64_t i = 0; i < cur_max_char; ++i) {
+    cur_alphabet_size >>= 1;
+    for (uint64_t i = 0; i < cur_alphabet_size; ++i) {
       ctx.hist(level, i)
         = ctx.hist(level + 1, i << 1)
         + ctx.hist(level + 1, (i << 1) + 1);
@@ -44,7 +44,7 @@ void ps(AlphabetType const* const text, uint64_t const size,
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
     borders[0] = 0;
-    for (uint64_t i = 1; i < cur_max_char; ++i) {
+    for (uint64_t i = 1; i < cur_alphabet_size; ++i) {
       auto const prev_rho = ctx.rho(level, i - 1);
 
       borders[ctx.rho(level, i)] =

--- a/include/construction/ps.hpp
+++ b/include/construction/ps.hpp
@@ -105,9 +105,7 @@ void ps(AlphabetType const* const text, uint64_t const size,
     }
   }
 
-  if (levels > 1) { // TODO check condition
-    ctx.hist(0, 0) = ctx.hist(1, 0) + ctx.hist(1, 1);
-  }
+  ctx.hist(0, 0) = size;
 }
 
 /******************************************************************************/

--- a/include/huffman/huff_building_blocks.hpp
+++ b/include/huffman/huff_building_blocks.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * include/huffman/huff_building_blocks.hpp
+ *
+ * Copyright (C) 2018 Marvin Löbel <loebel.marvin@gmail.com>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+
+#include "construction/building_blocks.hpp"
+
+template<typename text_t, typename ctx_t, typename bv_t, typename codes_t>
+inline void huff_scan_text_compute_first_level_bv_and_full_hist(
+  text_t const& text,
+  size_t const size,
+  bv_t& bv,
+  ctx_t& ctx,
+  codes_t const& codes
+) {
+    ctx.hist(0, 0) = size;
+
+    auto process_symbol = [&](auto& word, auto pos) {
+      const code_pair cp = codes.encode_symbol(text[pos]);
+      word <<= 1;
+      word |= cp[0];
+      // TODO: Try to find more efficient scheme that does not
+      // do O(level) individual add operations.
+      //
+      // Eg, just adding at code_length, and summing all up afterwards?
+      for (size_t level = 1; level <= cp.code_length; level++) {
+        auto prefix = cp.prefix(level);
+        ctx.hist(level, prefix)++;
+      }
+    };
+
+    uint64_t cur_pos = 0;
+    for (; cur_pos + 64 <= size; cur_pos += 64) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < 64; ++i) {
+        process_symbol(word, cur_pos + i);
+      }
+      bv[0][cur_pos >> 6] = word;
+    }
+    if (size & 63ULL) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < size - cur_pos; ++i) {
+        process_symbol(word, cur_pos + i);
+      }
+      word <<= (64 - (size & 63ULL));
+      bv[0][size >> 6] = word;
+    }
+}

--- a/include/huffman/huff_pc.hpp
+++ b/include/huffman/huff_pc.hpp
@@ -36,7 +36,7 @@ void huff_pc(AlphabetType const* text,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    compute_borders_and_optional_zeros(level, blocks, ctx);
+    compute_borders_and_optional_zeros_and_optional_rho(level, blocks, ctx);
 
     // Now we insert the bits with respect to their bit prefixes
     for (uint64_t i = 0; i < size; ++i) {

--- a/include/huffman/huff_pc.hpp
+++ b/include/huffman/huff_pc.hpp
@@ -32,7 +32,7 @@ void huff_pc(AlphabetType const* text,
   );
 
   // Now we compute the WX top-down, since the histograms are already computed
-  for (uint64_t level = 1; level < levels; level++) {
+  for (uint64_t level = levels - 1; level > 0; --level) {
     uint64_t blocks = 1ull << level;
 
     // Compute the starting positions of characters with respect to their
@@ -49,13 +49,9 @@ void huff_pc(AlphabetType const* text,
       // Since those codes will not be used in the loop below, this does not
       // produce wrong or out-of-bound accesses.
 
-      DCHECK(!ContextType::compute_rho);
-      // TODO: Due to the forward iteration, this can not currently work
-      /*
       if (ContextType::compute_rho)  {
         ctx.set_rho(level - 1, i - 1, prev_block >> 1);
       }
-      */
     }
 
     if (ContextType::compute_zeros) {

--- a/include/huffman/huff_pc.hpp
+++ b/include/huffman/huff_pc.hpp
@@ -22,7 +22,6 @@ void huff_pc(AlphabetType const* text,
              HuffCodes const& codes,
              ContextType& ctx)
 {
-  auto& zeros = ctx.zeros();
   auto& borders = ctx.borders();
   auto& bv = ctx.bv();
 
@@ -37,29 +36,7 @@ void huff_pc(AlphabetType const* text,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    borders[0] = 0;
-    for (uint64_t i = 1; i < blocks; ++i) {
-      auto const prev_block = ctx.rho(level, i - 1);
-      auto const this_block = ctx.rho(level, i);
-
-      borders[this_block] = borders[prev_block] + ctx.hist(level, prev_block);
-      // NB: The above calulcation produces _wrong_ border offsets
-      // for huffman codes that are one-shorter than the current level.
-      //
-      // Since those codes will not be used in the loop below, this does not
-      // produce wrong or out-of-bound accesses.
-
-      if (ContextType::compute_rho)  {
-        ctx.set_rho(level - 1, i - 1, prev_block >> 1);
-      }
-    }
-
-    if (ContextType::compute_zeros) {
-      // If we compute zeros, we are working on a WM instead of a WT.
-      // For a WM, borders is permuted with rho such that
-      // borders[1] contains the position of the first 1-bit block.
-      zeros[level - 1] = borders[1];
-    }
+    compute_borders_and_optional_zeros(level, blocks, ctx);
 
     // Now we insert the bits with respect to their bit prefixes
     for (uint64_t i = 0; i < size; ++i) {

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -85,30 +85,12 @@ void huff_ps(AlphabetType const* text,
     uint64_t const level_size = level_sizes[level];
 
     // Now we insert the bits with respect to their bit prefixes
-    uint64_t cur_pos = 0;
-    for (cur_pos = 0; cur_pos + 64 <= level_size; cur_pos += 64) {
-      uint64_t word = 0ULL;
-      for (uint64_t i = 0; i < 64; ++i) {
-        const code_pair cp = codes.encode_symbol(sorted_text[cur_pos + i]);
-        DCHECK(level < cp.code_length);
-        uint64_t const bit = cp[level];
-        word <<= 1;
-        word |= bit;
-      }
-      bv[level][cur_pos >> 6] = word;
-    }
-    if (level_size & 63ULL) {
-      uint64_t word = 0ULL;
-      for (uint64_t i = cur_pos; i < level_size; ++i) {
-        const code_pair cp = codes.encode_symbol(sorted_text[i]);
-        DCHECK(level < cp.code_length);
-        uint64_t const bit = cp[level];
-        word <<= 1;
-        word |= bit;
-      }
-      word <<= (64 - (level_size & 63ULL));
-      bv[level][level_size >> 6] = word;
-    }
+    write_bits_wordwise(0, level_size, bv[level], [&](uint64_t const i) {
+      const code_pair cp = codes.encode_symbol(sorted_text[i]);
+      DCHECK(level < cp.code_length);
+      uint64_t const bit = cp[level];
+      return bit;
+    });
   }
 }
 

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -34,7 +34,7 @@ void huff_ps(AlphabetType const* text,
   );
 
   // Now we compute the WX top-down, since the histograms are already computed
-  for (uint64_t level = 1; level < levels; level++) {
+  for (uint64_t level = levels - 1; level > 0; --level) {
     uint64_t blocks = 1ull << level;
 
     // Compute the starting positions of characters with respect to their
@@ -51,13 +51,9 @@ void huff_ps(AlphabetType const* text,
       // Since those codes will not be used in the loop below, this does not
       // produce wrong or out-of-bound accesses.
 
-      DCHECK(!ContextType::compute_rho);
-      // TODO: Due to the forward iteration, this can not currently work
-      /*
       if (ContextType::compute_rho)  {
         ctx.set_rho(level - 1, i - 1, prev_block >> 1);
       }
-      */
     }
 
     if (ContextType::compute_zeros) {

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -73,6 +73,8 @@ void huff_ps(AlphabetType const* text,
       auto const cur_char = text[i];
       const code_pair cp = codes.encode_symbol(cur_char);
 
+      // TODO: Make use of previously reduced sorted_text to
+      // reduce iteration time?
       if (level < cp.code_length) {
         uint64_t const prefix = cp.prefix(level);
         uint64_t const pos = borders[prefix]++;

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -38,7 +38,7 @@ void huff_ps(AlphabetType const* text,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    compute_borders_and_optional_zeros(level, blocks, ctx);
+    compute_borders_and_optional_zeros_and_optional_rho(level, blocks, ctx);
 
     // Now we sort the text utilizing counting sort and the starting positions
     // that we have computed before

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -24,7 +24,6 @@ void huff_ps(AlphabetType const* text,
              AlphabetType* const sorted_text,
              std::vector<uint64_t> const& level_sizes)
 {
-  auto& zeros = ctx.zeros();
   auto& borders = ctx.borders();
   auto& bv = ctx.bv();
 
@@ -39,29 +38,7 @@ void huff_ps(AlphabetType const* text,
 
     // Compute the starting positions of characters with respect to their
     // bit prefixes and the bit-reversal permutation
-    borders[0] = 0;
-    for (uint64_t i = 1; i < blocks; ++i) {
-      auto const prev_block = ctx.rho(level, i - 1);
-      auto const this_block = ctx.rho(level, i);
-
-      borders[this_block] = borders[prev_block] + ctx.hist(level, prev_block);
-      // NB: The above calulcation produces _wrong_ border offsets
-      // for huffman codes that are one-shorter than the current level.
-      //
-      // Since those codes will not be used in the loop below, this does not
-      // produce wrong or out-of-bound accesses.
-
-      if (ContextType::compute_rho)  {
-        ctx.set_rho(level - 1, i - 1, prev_block >> 1);
-      }
-    }
-
-    if (ContextType::compute_zeros) {
-      // If we compute zeros, we are working on a WM instead of a WT.
-      // For a WM, borders is permuted with rho such that
-      // borders[1] contains the position of the first 1-bit block.
-      zeros[level - 1] = borders[1];
-    }
+    compute_borders_and_optional_zeros(level, blocks, ctx);
 
     // Now we sort the text utilizing counting sort and the starting positions
     // that we have computed before

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -85,15 +85,29 @@ void huff_ps(AlphabetType const* text,
     uint64_t const level_size = level_sizes[level];
 
     // Now we insert the bits with respect to their bit prefixes
-    for (uint64_t i = 0; i < level_size; ++i) {
-      const code_pair cp = codes.encode_symbol(sorted_text[i]);
-      DCHECK(level < cp.code_length);
-
-      uint64_t const bit = cp[level];
-
-      // TODO: Write 1-word at a time
-      uint64_t const word_pos = 63ULL - (i & 63ULL);
-      bv[level][i >> 6] |= (bit << word_pos);
+    uint64_t cur_pos = 0;
+    for (cur_pos = 0; cur_pos + 64 <= level_size; cur_pos += 64) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = 0; i < 64; ++i) {
+        const code_pair cp = codes.encode_symbol(sorted_text[cur_pos + i]);
+        DCHECK(level < cp.code_length);
+        uint64_t const bit = cp[level];
+        word <<= 1;
+        word |= bit;
+      }
+      bv[level][cur_pos >> 6] = word;
+    }
+    if (level_size & 63ULL) {
+      uint64_t word = 0ULL;
+      for (uint64_t i = cur_pos; i < level_size; ++i) {
+        const code_pair cp = codes.encode_symbol(sorted_text[i]);
+        DCHECK(level < cp.code_length);
+        uint64_t const bit = cp[level];
+        word <<= 1;
+        word |= bit;
+      }
+      word <<= (64 - (level_size & 63ULL));
+      bv[level][level_size >> 6] = word;
     }
   }
 }

--- a/include/huffman/huff_ps.hpp
+++ b/include/huffman/huff_ps.hpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include "huffman/huff_codes.hpp"
+#include "huffman/huff_building_blocks.hpp"
 
 template <typename AlphabetType, typename ContextType, typename HuffCodes>
 void huff_ps(AlphabetType const* text,
@@ -28,36 +29,9 @@ void huff_ps(AlphabetType const* text,
   auto& bv = ctx.bv();
 
   // While calculating the histogram, we also compute the first level
-  {
-    ctx.hist(0, 0) = size;
-
-    auto process_symbol = [&](auto& word, auto pos) {
-      const code_pair cp = codes.encode_symbol(text[pos]);
-      word <<= 1;
-      word |= cp[0];
-      for (size_t level = 1; level <= cp.code_length; level++) {
-        auto prefix = cp.prefix(level);
-        ctx.hist(level, prefix)++;
-      }
-    };
-
-    uint64_t cur_pos = 0;
-    for (; cur_pos + 64 <= size; cur_pos += 64) {
-      uint64_t word = 0ULL;
-      for (uint64_t i = 0; i < 64; ++i) {
-        process_symbol(word, cur_pos + i);
-      }
-      bv[0][cur_pos >> 6] = word;
-    }
-    if (size & 63ULL) {
-      uint64_t word = 0ULL;
-      for (uint64_t i = 0; i < size - cur_pos; ++i) {
-        process_symbol(word, cur_pos + i);
-      }
-      word <<= (64 - (size & 63ULL));
-      bv[0][size >> 6] = word;
-    }
-  }
+  huff_scan_text_compute_first_level_bv_and_full_hist(
+    text, size, bv, ctx, codes
+  );
 
   // Now we compute the WX top-down, since the histograms are already computed
   for (uint64_t level = 1; level < levels; level++) {

--- a/include/wx_ppc.hpp
+++ b/include/wx_ppc.hpp
@@ -120,7 +120,8 @@ public:
 
         // TODO: Address the previous comment, to allow replace the
         // below code with this:
-        // compute_borders_and_optional_zeros(level, local_alphabet_size, ctx);
+        // compute_borders_and_optional_zeros_and_optional_rho(
+        //   level, local_alphabet_size, ctx);
 
         borders[0] = 0;
         for (uint64_t i = 1; i < local_alphabet_size; ++i) {

--- a/include/wx_ppc.hpp
+++ b/include/wx_ppc.hpp
@@ -13,6 +13,7 @@
 #include "construction/ctx_all_levels.hpp"
 #include "construction/wavelet_structure.hpp"
 #include "util/common.hpp"
+#include "construction/building_blocks.hpp"
 
 template <typename AlphabetType, bool is_tree_>
 class wx_ppc {

--- a/include/wx_ppc.hpp
+++ b/include/wx_ppc.hpp
@@ -118,6 +118,10 @@ public:
         // TODO: Add this local borders to the "new" context, too.
         std::vector<uint64_t> borders(local_alphabet_size, 0);
 
+        // TODO: Address the previous comment, to allow replace the
+        // below code with this:
+        // compute_borders_and_optional_zeros(level, local_alphabet_size, ctx);
+
         borders[0] = 0;
         for (uint64_t i = 1; i < local_alphabet_size; ++i) {
           const auto prev_rho = ctx.rho(level, i - 1);

--- a/include/wx_ppc.hpp
+++ b/include/wx_ppc.hpp
@@ -47,10 +47,10 @@ public:
     {
       const uint64_t omp_rank = uint64_t(omp_get_thread_num());
       const uint64_t omp_size = uint64_t(omp_get_num_threads());
-      const uint64_t max_char = (1 << levels);
+      const uint64_t alphabet_size = (1 << levels);
 
       auto* const initial_hist_ptr =
-        initial_hist.data() + (max_char * omp_rank);
+        initial_hist.data() + (alphabet_size * omp_rank);
 
       #pragma omp for
       for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
@@ -78,9 +78,9 @@ public:
 
       // Compute the historam with respect to the local slices of the text
       #pragma omp for
-      for (uint64_t i = 0; i < max_char; ++i) {
+      for (uint64_t i = 0; i < alphabet_size; ++i) {
         for (uint64_t rank = 0; rank < omp_size; ++rank) {
-          ctx.hist(levels, i) += *(initial_hist.data() + (max_char * rank) + i);
+          ctx.hist(levels, i) += *(initial_hist.data() + (alphabet_size * rank) + i);
         }
       }
 
@@ -88,7 +88,7 @@ public:
       {
         if constexpr (ctx_t::compute_zeros) {
           // The number of 0s at the last level is the number of "even" characters
-          for (uint64_t i = 0; i < max_char; i += 2) {
+          for (uint64_t i = 0; i < alphabet_size; i += 2) {
             zeros[levels - 1] += ctx.hist(levels, i);
           }
         }
@@ -97,9 +97,9 @@ public:
       // Compute the histogram for each level of the wavelet structure
       #pragma omp for
       for (uint64_t level = 1; level < levels; ++level) {
-        const uint64_t local_max_char = (1 << level);
+        const uint64_t local_alphabet_size = (1 << level);
         const uint64_t requierd_characters = (1 << (levels - level));
-        for (uint64_t i = 0; i < local_max_char; ++i) {
+        for (uint64_t i = 0; i < local_alphabet_size; ++i) {
           for (uint64_t j = 0; j < requierd_characters; ++j) {
             ctx.hist(level, i) +=
               ctx.hist(levels, (i * requierd_characters) + j);
@@ -111,15 +111,15 @@ public:
       #pragma omp for
       for (uint64_t level = 1; level < levels; ++level) {
 
-        const uint64_t local_max_char = (1 << level);
+        const uint64_t local_alphabet_size = (1 << level);
         const uint64_t prefix_shift = (levels - level);
         const uint64_t cur_bit_shift = prefix_shift - 1;
 
         // TODO: Add this local borders to the "new" context, too.
-        std::vector<uint64_t> borders(local_max_char, 0);
+        std::vector<uint64_t> borders(local_alphabet_size, 0);
 
         borders[0] = 0;
-        for (uint64_t i = 1; i < local_max_char; ++i) {
+        for (uint64_t i = 1; i < local_alphabet_size; ++i) {
           const auto prev_rho = ctx.rho(level, i - 1);
           borders[ctx.rho(level, i)] =
             borders[prev_rho] + ctx.hist(level, prev_rho);

--- a/include/wx_ppc_ss.hpp
+++ b/include/wx_ppc_ss.hpp
@@ -13,6 +13,7 @@
 #include "construction/ctx_compute_borders.hpp"
 #include "construction/pc_ss.hpp"
 #include "construction/wavelet_structure.hpp"
+#include "construction/building_blocks.hpp"
 
 template <typename AlphabteType, bool is_tree_>
 class wx_ppc_ss {
@@ -40,9 +41,9 @@ public:
     auto& zeros = ctx.zeros();
 
     const uint64_t max_char = (1 << levels);
-    
-    std::vector<std::vector<uint64_t>> all_hists; 
-    
+
+    std::vector<std::vector<uint64_t>> all_hists;
+
     #pragma omp parallel
     {
       const auto omp_rank = omp_get_thread_num();
@@ -86,7 +87,8 @@ public:
         zeros[levels - 1] += ctx.hist(levels, i);
       }
     }
-    ctx.fill_borders();
+
+    bottom_up_compute_hist_and_borders_and_optional_zeros(size, levels, ctx);
 
     // TODO: Is this correct?
     #pragma omp parallel num_threads(levels)

--- a/include/wx_ppc_ss.hpp
+++ b/include/wx_ppc_ss.hpp
@@ -40,7 +40,7 @@ public:
     auto& bv = ctx.bv();
     auto& zeros = ctx.zeros();
 
-    const uint64_t max_char = (1 << levels);
+    const uint64_t alphabet_size = (1 << levels);
 
     std::vector<std::vector<uint64_t>> all_hists;
 
@@ -51,7 +51,7 @@ public:
 
       #pragma omp single
       all_hists = std::vector<std::vector<uint64_t>>(omp_size,
-        std::vector<uint64_t>(max_char + 1, 0));
+        std::vector<uint64_t>(alphabet_size + 1, 0));
 
       #pragma omp for
       for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
@@ -78,12 +78,12 @@ public:
     }
 
     for (uint64_t i = 0; i < all_hists.size(); ++i) {
-      for (uint64_t j = 0; j < max_char; ++j) {
+      for (uint64_t j = 0; j < alphabet_size; ++j) {
         ctx.hist(levels, j) += all_hists[i][j];
       }
     }
     if constexpr (ctx_t::compute_zeros) {
-      for (uint64_t i = 0; i < max_char; i += 2) {
+      for (uint64_t i = 0; i < alphabet_size; i += 2) {
         zeros[levels - 1] += ctx.hist(levels, i);
       }
     }

--- a/include/wx_ppc_ss.hpp
+++ b/include/wx_ppc_ss.hpp
@@ -95,11 +95,11 @@ public:
     {
       uint64_t level = omp_get_thread_num();
       for (uint64_t i = 0; i < size; ++i) {
-          const uint64_t prefix_shift = (levels - level);
-          const uint64_t cur_bit_shift = prefix_shift - 1;
-          const uint64_t pos = ctx.borders(level, text[i] >> prefix_shift)++;
-          bv[level][pos >> 6] |= (((text[i] >> cur_bit_shift) & 1ULL)
-            << (63ULL - (pos & 63ULL)));
+        const uint64_t prefix_shift = (levels - level);
+        const uint64_t cur_bit_shift = prefix_shift - 1;
+        const uint64_t pos = ctx.borders(level, text[i] >> prefix_shift)++;
+        bv[level][pos >> 6] |= (((text[i] >> cur_bit_shift) & 1ULL)
+          << (63ULL - (pos & 63ULL)));
       }
     }
 

--- a/include/wx_ppc_ss.hpp
+++ b/include/wx_ppc_ss.hpp
@@ -93,11 +93,11 @@ public:
     {
       uint64_t level = omp_get_thread_num();
       for (uint64_t i = 0; i < size; ++i) {
-        const uint64_t prefix_shift = (levels - level);
-        const uint64_t cur_bit_shift = prefix_shift - 1;
-        const uint64_t pos = ctx.borders(level, text[i] >> prefix_shift)++;
-        bv[level][pos >> 6] |= (((text[i] >> cur_bit_shift) & 1ULL)
-          << (63ULL - (pos & 63ULL)));
+          const uint64_t prefix_shift = (levels - level);
+          const uint64_t cur_bit_shift = prefix_shift - 1;
+          const uint64_t pos = ctx.borders(level, text[i] >> prefix_shift)++;
+          bv[level][pos >> 6] |= (((text[i] >> cur_bit_shift) & 1ULL)
+            << (63ULL - (pos & 63ULL)));
       }
     }
 

--- a/include/wx_pps.hpp
+++ b/include/wx_pps.hpp
@@ -14,6 +14,7 @@
 #include "util/common.hpp"
 #include "construction/ctx_sliced_single_level.hpp"
 #include "construction/wavelet_structure.hpp"
+#include "construction/building_blocks.hpp"
 
 template <typename AlphabetType, bool is_tree_>
 class wx_pps {
@@ -51,7 +52,7 @@ public:
       auto& bv = ctx.bv();
       auto& zeros = ctx.zeros();
 
-      // While initializing the histogram, we also compute the fist level
+      // While initializing the histogram, we also compute the first level
       #pragma omp for
       for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
         uint64_t word = 0ULL;


### PR DESCRIPTION
This factors out a few common computation of the different implementations into central functions to reduce the amount of copy-pasted code.