### PR TITLE
Add clang-format wrapper script to correctly indent omp pragmas

### DIFF
--- a/external/p-clang-format/LICENSE
+++ b/external/p-clang-format/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Medicine Yeh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external/p-clang-format/README.md
+++ b/external/p-clang-format/README.md
@@ -1,0 +1,21 @@
+# Introduction
+__clang-format__ is a great tool but yet some features are still missing for many years.
+This project helps you to format `#pragma omp`, `#pragma unroll`, etc. with the right indent.
+
+The name of this project comes from patched __clang-format__.
+There are many usages brought by this script binary to help patch the formating rules of __clang-format__.
+
+# Usage
+* Use it the way you use `clang-format`
+* You can also run with env var to replace any pragma `REPLACE_ANY_PRAGMA=1 ./p-clang-format ...`
+
+# Vim Autoformat support
+If you are interested in how this works or how to add this capability to your vim script,
+please refer to this [blog](https://medicineyeh.wordpress.com/2017/07/13/clang-format-with-pragma/)
+
+# Install
+Simply copy this binary to any folder listed in `$PATH` or `/usr/bin/`.
+
+# License
+MIT License.
+

--- a/external/p-clang-format/p-clang-format
+++ b/external/p-clang-format/p-clang-format
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Copyright (c) 2017, Medicine Yeh
+# MIT License
+
+# Turn on this to replace any pragma
+#REPLACE_ANY_PRAGMA=1
+
+function replace_all()
+{
+    local prefix="$1"
+    local keywords=("${!2}")
+    local pattern="$3"
+    local file_pathes=("${!4}")
+
+    # echo "Keywords     : ${keywords[*]}"
+    # echo "Pattern      : ${pattern}"
+    # echo "File Path    : ${file_pathes[*]}"
+
+    for file_path in "${file_pathes[@]}"; do
+        [[ ! -r "$file_path" ]] && continue
+        for w in "${keywords[@]}"; do
+            # echo "Replace '${prefix}$w' in '$file_path'"
+            sed -i "s/${prefix}${w}/${pattern}${prefix}${w}/g" "${file_path}"
+        done
+    done
+}
+
+function re_replace_all()
+{
+    local prefix="$1"
+    local keywords=("${!2}")
+    local pattern="$3"
+    local file_pathes=("${!4}")
+
+    # echo "Keywords     : ${keywords[*]}"
+    # echo "Anti-Pattern : ${pattern}"
+    # echo "File Path    : ${file_pathes[*]}"
+
+    for file_path in "${file_pathes[@]}"; do
+        [[ ! -r "$file_path" ]] && continue
+        for w in "${keywords[@]}"; do
+            # echo "Re:replace '${prefix}$w' in '$file_path'"
+            sed -i "s/${pattern}${prefix}${w}/${prefix}${w}/g" "${file_path}"
+        done
+    done
+}
+
+function format()
+{
+    clang-format "$@"
+}
+
+function main()
+{
+    # This is the pattern for replacing to comments
+    local comment_pattern="\/\/"
+    # This is the pattern for replacing comments back to original string
+    local re_comment_pattern="\/\/ *"
+    # The path of files
+    local file_pathes=()
+    # Define the keywords of pragma to be escaped from formatting
+    local pragma_prefix="#pragma "
+    local pragma_key_words=()
+    # Loop specific
+    pragma_key_words+=(omp simd loop unroll ivdep vector)
+    # Memory specific
+    pragma_key_words+=(alloc_section)
+    # Misc.
+    pragma_key_words+=("cilk grainsize" offload)
+
+    # Turn on the following line to indent any pragma
+    [[ "$REPLACE_ANY_PRAGMA" == "1" ]] && pragma_key_words=("")
+
+    # Find all files in the arguments
+    for var in "$@"; do
+        if [[ ! "$var" =~ ^-.* ]]; then
+            file_pathes+=("$var")
+        fi
+    done
+
+    replace_all "$pragma_prefix" "pragma_key_words[@]" "$comment_pattern" "file_pathes[@]"
+    format "$@"
+    re_replace_all "$pragma_prefix" "pragma_key_words[@]" "$re_comment_pattern" "file_pathes[@]"
+}
+
+main "$@"
+

--- a/include/construction/merge.hpp
+++ b/include/construction/merge.hpp
@@ -369,7 +369,7 @@ inline auto merge_bit_vectors(uint64_t size,
   auto r = bit_vectors(levels, size);
   auto& _bv = r;
 
-#pragma omp parallel
+  #pragma omp parallel
   // for(size_t omp_rank = 0; omp_rank < shards; omp_rank++)
   {
     assert(size_t(omp_get_num_threads()) == shards);

--- a/include/huffman/huff_dd.hpp
+++ b/include/huffman/huff_dd.hpp
@@ -60,7 +60,7 @@ public:
       return slice.slice(offset, offset + local_size);
     };
 
-#pragma omp parallel for
+    #pragma omp parallel for
     for (size_t shard = 0; shard < shards; shard++) {
       auto text = get_local_slice(shard, global_text);
 
@@ -102,7 +102,7 @@ public:
         global_sorted_text_allocation.data(),
         global_sorted_text_allocation.size()};
 
-#pragma omp parallel for
+    #pragma omp parallel for
     for (size_t shard = 0; shard < shards; shard++) {
       std::vector<uint64_t> const& local_level_sizes =
           builder.level_sizes_shards()[shard];

--- a/include/huffman/huff_merge.hpp
+++ b/include/huffman/huff_merge.hpp
@@ -250,7 +250,7 @@ inline auto huff_merge_bit_vectors(std::vector<uint64_t> const& level_sizes,
   auto r = huff_bit_vectors(levels, level_sizes);
   auto& _bv = r;
 
-#pragma omp parallel for
+  #pragma omp parallel for
   for (size_t merge_shard = 0; merge_shard < shards; merge_shard++) {
     for (size_t level = 0; level < levels; level++) {
       auto& lctx = ctxs[merge_shard].levels[level];

--- a/include/wx_dd_pc.hpp
+++ b/include/wx_dd_pc.hpp
@@ -55,7 +55,7 @@ public:
       ctxs[shard] = ctx_t(local_size, levels, rho);
     }
 
-#pragma omp parallel
+    #pragma omp parallel
     {
       const uint64_t omp_rank = omp_get_thread_num();
       const uint64_t omp_size = omp_get_num_threads();
@@ -79,7 +79,7 @@ public:
     if constexpr (ctx_t::compute_zeros) {
       auto _zeros = std::vector<uint64_t>(levels, 0);
 
-#pragma omp parallel for
+      #pragma omp parallel for
       for (size_t level = 0; level < levels; level++) {
         for (size_t shard = 0; shard < ctxs.size(); shard++) {
           _zeros[level] += ctxs[shard].zeros()[level];

--- a/include/wx_dd_pc_ss.hpp
+++ b/include/wx_dd_pc_ss.hpp
@@ -54,7 +54,7 @@ public:
       ctxs[shard] = ctx_t(local_size, levels, rho);
     }
 
-#pragma omp parallel
+    #pragma omp parallel
     {
       const uint64_t omp_rank = omp_get_thread_num();
       const uint64_t omp_size = omp_get_num_threads();
@@ -78,7 +78,7 @@ public:
     if constexpr (ctx_t::compute_zeros) {
       auto _zeros = std::vector<uint64_t>(levels, 0);
 
-#pragma omp parallel for
+      #pragma omp parallel for
       for (size_t level = 0; level < levels; level++) {
         for (size_t shard = 0; shard < ctxs.size(); shard++) {
           _zeros[level] += ctxs[shard].zeros()[level];

--- a/include/wx_dd_ps.hpp
+++ b/include/wx_dd_ps.hpp
@@ -58,7 +58,7 @@ public:
 
     auto global_sorted_text = std::vector<AlphabetType>(size);
 
-#pragma omp parallel
+    #pragma omp parallel
     {
       const uint64_t omp_rank = omp_get_thread_num();
       const uint64_t omp_size = omp_get_num_threads();
@@ -85,7 +85,7 @@ public:
     if constexpr (ctx_t::compute_zeros) {
       auto _zeros = std::vector<uint64_t>(levels, 0);
 
-#pragma omp parallel for
+      #pragma omp parallel for
       for (size_t level = 0; level < levels; level++) {
         for (size_t shard = 0; shard < ctxs.size(); shard++) {
           _zeros[level] += ctxs[shard].zeros()[level];

--- a/include/wx_ppc.hpp
+++ b/include/wx_ppc.hpp
@@ -46,7 +46,7 @@ public:
 
     std::vector<uint64_t> initial_hist((1ULL << levels) * levels, 0);
 
-#pragma omp parallel num_threads(levels)
+    #pragma omp parallel num_threads(levels)
     {
       const uint64_t omp_rank = uint64_t(omp_get_thread_num());
       const uint64_t omp_size = uint64_t(omp_get_num_threads());
@@ -55,7 +55,7 @@ public:
       auto* const initial_hist_ptr =
           initial_hist.data() + (alphabet_size * omp_rank);
 
-#pragma omp for
+      #pragma omp for
       for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
         uint64_t word = 0ULL;
         for (uint64_t i = 0; i < 64; ++i) {
@@ -77,10 +77,10 @@ public:
         bv[0][size >> 6] = word;
       }
 
-#pragma omp barrier
+      #pragma omp barrier
 
-// Compute the historam with respect to the local slices of the text
-#pragma omp for
+      // Compute the historam with respect to the local slices of the text
+      #pragma omp for
       for (uint64_t i = 0; i < alphabet_size; ++i) {
         for (uint64_t rank = 0; rank < omp_size; ++rank) {
           ctx.hist(levels, i) +=
@@ -88,7 +88,7 @@ public:
         }
       }
 
-#pragma omp single
+      #pragma omp single
       {
         if constexpr (ctx_t::compute_zeros) {
           // The number of 0s at the last level is the number of "even"
@@ -99,8 +99,8 @@ public:
         }
       }
 
-// Compute the histogram for each level of the wavelet structure
-#pragma omp for
+      // Compute the histogram for each level of the wavelet structure
+      #pragma omp for
       for (uint64_t level = 1; level < levels; ++level) {
         const uint64_t local_alphabet_size = (1 << level);
         const uint64_t requierd_characters = (1 << (levels - level));
@@ -112,8 +112,9 @@ public:
         }
       }
 
-// Now we compute the wavelet structure bottom-up, i.e., the last level first
-#pragma omp for
+      // Now we compute the wavelet structure bottom-up, i.e., the last level
+      // first
+      #pragma omp for
       for (uint64_t level = 1; level < levels; ++level) {
 
         const uint64_t local_alphabet_size = (1 << level);

--- a/include/wx_ppc_ss.hpp
+++ b/include/wx_ppc_ss.hpp
@@ -47,16 +47,16 @@ public:
 
     std::vector<std::vector<uint64_t>> all_hists;
 
-#pragma omp parallel
+    #pragma omp parallel
     {
       const auto omp_rank = omp_get_thread_num();
       const auto omp_size = omp_get_num_threads();
 
-#pragma omp single
+      #pragma omp single
       all_hists = std::vector<std::vector<uint64_t>>(
           omp_size, std::vector<uint64_t>(alphabet_size + 1, 0));
 
-#pragma omp for
+      #pragma omp for
       for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
         uint64_t word = 0ULL;
         for (uint64_t i = 0; i < 64; ++i) {
@@ -93,8 +93,8 @@ public:
 
     bottom_up_compute_hist_and_borders_and_optional_zeros(size, levels, ctx);
 
-// TODO: Is this correct?
-#pragma omp parallel num_threads(levels)
+    // TODO: Is this correct?
+    #pragma omp parallel num_threads(levels)
     {
       uint64_t level = omp_get_thread_num();
       for (uint64_t i = 0; i < size; ++i) {

--- a/include/wx_pps.hpp
+++ b/include/wx_pps.hpp
@@ -43,20 +43,20 @@ public:
     std::vector<AlphabetType> sorted_text(size);
     std::vector<uint64_t> offsets(1 << levels, 0);
 
-#pragma omp parallel
+    #pragma omp parallel
     {
       const auto omp_rank = omp_get_thread_num();
       const auto omp_size = omp_get_num_threads();
       const uint64_t alphabet_size = (1 << levels);
 
-#pragma omp single
+      #pragma omp single
       ctx = ctx_t(size, levels, omp_size);
 
       auto& bv = ctx.bv();
       auto& zeros = ctx.zeros();
 
-// While initializing the histogram, we also compute the first level
-#pragma omp for
+      // While initializing the histogram, we also compute the first level
+      #pragma omp for
       for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
         uint64_t word = 0ULL;
         for (uint64_t i = 0; i < 64; ++i) {
@@ -77,8 +77,8 @@ public:
         bv[0][size >> 6] = word;
       }
 
-// The number of 0's at the last level is the number of "even" characters
-#pragma omp single
+      // The number of 0's at the last level is the number of "even" characters
+      #pragma omp single
       for (uint64_t i = 0; i < alphabet_size; i += 2) {
         for (int32_t rank = 0; rank < omp_size; ++rank) {
           zeros[levels - 1] += ctx.hist(rank, i);
@@ -91,10 +91,10 @@ public:
         const uint64_t prefix_shift = (levels - level);
         const uint64_t cur_bit_shift = prefix_shift - 1;
 
-// Compute the histogram and the border for each bit prefix and
-// processor, i.e., for one fixed bit prefix we compute the prefix sum
-// over the number of occurrences at each processor
-#pragma omp for
+        // Compute the histogram and the border for each bit prefix and
+        // processor, i.e., for one fixed bit prefix we compute the prefix sum
+        // over the number of occurrences at each processor
+        #pragma omp for
         for (uint64_t i = 0; i < alphabet_size; i += (1ULL << prefix_shift)) {
           ctx.borders(0, i) = 0;
           ctx.hist(0, i) += ctx.hist(0, i + (1ULL << cur_bit_shift));
@@ -105,9 +105,9 @@ public:
           }
         }
 
-// Now we compute the offset for each bit prefix, i.e., the number of
-// lexicographically smaller characters
-#pragma omp single
+        // Now we compute the offset for each bit prefix, i.e., the number of
+        // lexicographically smaller characters
+        #pragma omp single
         {
           for (uint64_t i = 1; i < (1ULL << level); ++i) {
             const auto prev_rho = ctx.rho(level, i - 1);
@@ -125,8 +125,8 @@ public:
             zeros[level - 1] = offsets[1ULL << prefix_shift];
           }
         }
-// We add the offset to the borders (for performance)
-#pragma omp for
+        // We add the offset to the borders (for performance)
+        #pragma omp for
         for (int32_t rank = 0; rank < omp_size; ++rank) {
           for (uint64_t i = 0; i < alphabet_size; i += (1ULL << prefix_shift)) {
             ctx.borders(rank, i) += offsets[i];
@@ -140,8 +140,8 @@ public:
           borders_aligned[i >> prefix_shift] = ctx.borders(omp_rank, i);
         }
 
-// Sort the text using the computed (and aligned) borders
-#pragma omp for
+        // Sort the text using the computed (and aligned) borders
+        #pragma omp for
         for (uint64_t i = 0; i <= size - 64; i += 64) {
           for (uint64_t j = 0; j < 64; ++j) {
             const AlphabetType considerd_char = (text[i + j] >> cur_bit_shift);
@@ -157,12 +157,12 @@ public:
           }
         }
 
-#pragma omp barrier
+        #pragma omp barrier
 
-// Since we have sorted the text, we can simply scan it from left to
-// right and for the character at position $i$ we set the $i$-th bit in
-// the bit vector accordingly
-#pragma omp for
+        // Since we have sorted the text, we can simply scan it from left to
+        // right and for the character at position $i$ we set the $i$-th bit in
+        // the bit vector accordingly
+        #pragma omp for
         for (uint64_t cur_pos = 0; cur_pos <= size - 64; cur_pos += 64) {
           uint64_t word = 0ULL;
           for (uint64_t i = 0; i < 64; ++i) {


### PR DESCRIPTION
The normal `clang-format` un-indents all pragmas in a source file which, while technically correct according to the C++ standard, is unneeded for omp pragmas and makes the code arguably harder to read.

This adds a MIT-licensed wrapper script I've found somewhere that can be optionally used to handle pragmas correctly (it replaces pragmas with comments, and then does the reverse after code formatting).

Usage of `external/p-clang-format` is the same as for `clang-format`.