### PR TITLE
Fix performance and thread limit issues in ppc and ppc_ss

### DIFF
--- a/include/arrays/flat_two_dim_array.hpp
+++ b/include/arrays/flat_two_dim_array.hpp
@@ -23,28 +23,20 @@ public:
   base_flat_two_dim_array() = default;
 
   base_flat_two_dim_array(const uint64_t levels)
-      : levels_(levels), data_(levels + 1), level_bit_sizes_(levels) {
+      : levels_(levels), data_(levels), level_bit_sizes_(levels) {
     DCHECK(levels > 0);
   }
 
-  base_flat_two_dim_array(base_flat_two_dim_array&& other) = default;
+  base_flat_two_dim_array(base_flat_two_dim_array&& other) {
+    move_from(std::move(other));
+  }
   base_flat_two_dim_array& operator=(base_flat_two_dim_array&& other) {
-    if (*this != other) {
-      if (data_.size() > 0) {
-        delete[] data_[0];
-      }
-      data_ = std::move(other.data_);
-      levels_ = other.levels_;
-      other.levels_ = 0;
-      level_bit_sizes_ = std::move(other.level_bit_sizes_);
-    }
+    move_from(std::move(other));
     return *this;
   }
 
   ~base_flat_two_dim_array() {
-    if (data_.size() > 0) {
-      delete[] data_[0];
-    }
+    destroy();
   }
 
   base_flat_two_dim_array(const base_flat_two_dim_array&) = delete;
@@ -57,7 +49,7 @@ public:
     }
     // Here we know that either both have length 0 or both have length > 0.
     return ((data_.size() == 0 && other.data_.size() == 0) ||
-            data_[0] == other.data_[0]);
+            data_[0].data() == other.data_[0].data());
   }
 
   bool operator!=(const base_flat_two_dim_array& other) const {
@@ -74,36 +66,91 @@ public:
 
   inline span<IndexType const> operator[](const uint64_t index) const {
     DCHECK(index < levels());
-    auto ptr = data_[index];
-    auto nptr = data_[index + 1];
-    return {ptr, size_t(nptr - ptr)};
+    return data_[index];
   }
 
   inline span<IndexType> operator[](const uint64_t index) {
     DCHECK(index < levels());
-    auto ptr = data_[index];
-    auto nptr = data_[index + 1];
-    return {ptr, size_t(nptr - ptr)};
+    return data_[index];
   }
 
 protected:
-  inline const std::vector<IndexType*>& raw_data() const {
-    return data_;
-  }
-
-  inline std::vector<IndexType*>& raw_data() {
-    return data_;
-  }
-
   uint64_t levels_ = 0;
-  std::vector<IndexType*> data_;
+  std::vector<span<IndexType>> data_;
   std::vector<uint64_t> level_bit_sizes_;
+  IndexType* allocation_ = nullptr;
+
+  inline void destroy() {
+    if (data_.size() > 0) {
+      DCHECK(allocation_ != nullptr);
+      delete[] allocation_;
+    }
+  }
+
+  inline void move_from(base_flat_two_dim_array&& other) {
+    destroy();
+
+    data_ = std::move(other.data_);
+    level_bit_sizes_ = std::move(other.level_bit_sizes_);
+
+    levels_ = other.levels_;
+    other.levels_ = 0;
+
+    allocation_ = other.allocation_;
+    other.allocation_ = nullptr;
+  }
 
 }; // class base_flat_two_dim_array
 
+/// Aa 2D vector that stores the the different levels in a continous
+/// allocation.
+///
+/// Each level might be seprated by some padding to ensure they
+/// start in different cache lines.
 template <typename IndexType, class config>
 class flat_two_dim_array : public base_flat_two_dim_array<IndexType> {
   using base = base_flat_two_dim_array<IndexType>;
+
+  static_assert((CACHELINE_SIZE % sizeof(IndexType)) == 0);
+
+  inline static uint64_t
+  compute_elements_till_next_cacheline(uint64_t initial_idx) {
+    auto remainder = initial_idx % elements_per_cacheline();
+    if (remainder == 0) {
+      remainder = elements_per_cacheline();
+    }
+    return elements_per_cacheline() - remainder;
+  }
+  inline static uint64_t elements_per_cacheline() {
+    return CACHELINE_SIZE / sizeof(IndexType);
+  }
+  struct level_data_size_info {
+    uint64_t level_array_size;
+    uint64_t level_bit_size;
+    uint64_t level_array_size_plus_cacheline_align;
+  };
+  template <typename... SizeFunctionArgs>
+  inline static level_data_size_info
+  compute_level_size(uint64_t level, SizeFunctionArgs... size_f_args) {
+    const uint64_t level_size = config::level_size(level, size_f_args...);
+    level_data_size_info ret;
+
+    // If its a bit vector, we still want to knwo how many bits there are
+    // actually stored in each level, not just the number of computer words.
+    if constexpr (config::is_bit_vector) {
+      ret.level_bit_size = level_size;
+      ret.level_array_size = word_size(level_size);
+    } else {
+      ret.level_bit_size = level_size * (sizeof(IndexType) >> 3);
+      ret.level_array_size = level_size;
+    }
+
+    auto extra = compute_elements_till_next_cacheline(ret.level_array_size);
+
+    ret.level_array_size_plus_cacheline_align = ret.level_array_size + extra;
+
+    return ret;
+  }
 
 public:
   flat_two_dim_array() : base::base_flat_two_dim_array() {}
@@ -114,22 +161,24 @@ public:
 
     auto& level_bit_sizes_ = base::level_bit_sizes_;
     auto& data_ = base::data_;
+    DCHECK(data_.size() == levels);
 
+    // compute element counts and allocation size per level
     uint64_t data_size = 0;
     for (uint64_t level = 0; level < levels; ++level) {
-      const uint64_t level_size = config::level_size(level, size_f_args...);
-      // If its a bit vector, we still want to knwo how many bits there are
-      // actually stored in each level, not just the number of computer words.
-      if constexpr (config::is_bit_vector) {
-        level_bit_sizes_[level] = level_size;
-        data_size += word_size(level_size);
-      } else {
-        level_bit_sizes_[level] = level_size * (sizeof(IndexType) >> 3);
-        data_size += level_size;
-      }
-    }
-    data_[0] = new IndexType[data_size];
+      const auto info = compute_level_size(level, size_f_args...);
 
+      level_bit_sizes_[level] = info.level_bit_size;
+      data_size += info.level_array_size_plus_cacheline_align;
+    }
+
+    // We need to align the allocation to cachelines,
+    // so add some extra wiggle room
+    data_size += elements_per_cacheline();
+
+    // allocate and optionally initialize the data
+    auto& allocation_ = base::allocation_;
+    allocation_ = new IndexType[data_size];
     if constexpr (config::requires_initialization) {
       #pragma omp parallel
       {
@@ -141,17 +190,23 @@ public:
         const uint64_t offset =
             (omp_rank * (data_size / omp_size)) +
             std::min<uint64_t>(omp_rank, data_size % omp_size);
-        memset(data_[0] + offset, 0, local_size * sizeof(IndexType));
+        memset(allocation_ + offset, 0, local_size * sizeof(IndexType));
       }
     }
 
-    for (uint64_t level = 1; level < data_.size(); ++level) {
-      const uint64_t level_size = config::level_size(level - 1, size_f_args...);
-      if constexpr (config::is_bit_vector) {
-        data_[level] = data_[level - 1] + word_size(level_size);
-      } else {
-        data_[level] = data_[level - 1] + level_size;
-      }
+    // align first level pointer to the start of the next cacheline
+    auto aligned_ptr = allocation_;
+    auto ptr_addr = uint64_t(allocation_);
+    DCHECK(ptr_addr % sizeof(IndexType) == 0);
+    aligned_ptr +=
+        compute_elements_till_next_cacheline(ptr_addr / sizeof(IndexType));
+
+    // setup the spans pointing to the individual levels in the allocation
+    for (uint64_t level = 0; level < levels; ++level) {
+      const auto info = compute_level_size(level, size_f_args...);
+
+      data_.at(level) = span<IndexType>(aligned_ptr, info.level_array_size);
+      aligned_ptr += info.level_array_size_plus_cacheline_align;
     }
   }
 

--- a/include/construction/ppc.hpp
+++ b/include/construction/ppc.hpp
@@ -26,81 +26,62 @@ void ppc(AlphabetType const* text,
   // compute initial histogram
   {
     const uint64_t alphabet_size = (1ull << levels);
-    std::vector<uint64_t> initial_hist_v(alphabet_size * levels, 0);
-    span<uint64_t> initial_hist{initial_hist_v.data(), initial_hist_v.size()};
-    auto&& hist = ctx.hist_at_level(levels);
 
-    #pragma omp parallel num_threads(levels)
+    // Allocate a histogram buffer per thread
+    helper_array sharded_hists(omp_get_max_threads(), alphabet_size);
+
+    // Write the first level, and fill the histograms in parallel
+    #pragma omp parallel
     {
-      const uint64_t omp_rank = uint64_t(omp_get_thread_num());
-      DCHECK(levels == uint64_t(omp_get_num_threads()));
-
-      auto initial_hist_ptr = initial_hist.slice(
-          alphabet_size * omp_rank, alphabet_size * (omp_rank + 1));
+      const auto shard = omp_get_thread_num();
+      auto&& hist = sharded_hists[shard];
 
       omp_write_bits_wordwise(0, size, bv[0], [&](uint64_t const i) {
         auto const c = text[i];
-        initial_hist_ptr[c]++;
-        uint64_t bit = ((c >> (levels - 1)) & 1ULL);
+        hist[c]++;
+        uint64_t const bit = ((c >> (levels - 1)) & 1ULL);
         return bit;
       });
+    }
 
-      #pragma omp barrier
-
-      // Compute the histogram with respect to the local slices of the text
-      #pragma omp for
-      for (uint64_t i = 0; i < alphabet_size; ++i) {
-        for (uint64_t rank = 0; rank < levels; ++rank) {
-          hist[i] += initial_hist[(alphabet_size * rank) + i];
-        }
+    // Accumulate the histograms
+    auto&& hist = ctx.hist_at_level(levels);
+    #pragma omp parallel for
+    for (uint64_t j = 0; j < alphabet_size; ++j) {
+      for (uint64_t shard = 0; shard < sharded_hists.levels(); ++shard) {
+        hist[j] += sharded_hists[shard][j];
       }
     }
   }
 
   auto&& leaf_hist = ctx.hist_at_level(levels);
 
-  #pragma omp parallel num_threads(levels)
-  {
-    [[maybe_unused]]const uint64_t omp_rank_ = omp_get_thread_num();
-    DCHECK(omp_rank_ < levels);
-
-    // Compute the histogram for each level of the wavelet structure
-    #pragma omp for
-    for (uint64_t level = 1; level < levels; ++level) {
-      // TODO: remove again
-      [[maybe_unused]]const uint64_t omp_rank = omp_get_thread_num();
-      DCHECK(omp_rank < levels);
-      DCHECK(omp_rank == omp_rank_);
-
-      auto&& hist = ctx.hist_at_level(level);
-      const uint64_t blocks = (1 << level);
-      const uint64_t required_characters = (1 << (levels - level));
-      for (uint64_t i = 0; i < blocks; ++i) {
-        for (uint64_t j = 0; j < required_characters; ++j) {
-          hist[i] += leaf_hist[(i * required_characters) + j];
-        }
+  // Compute the histogram for each level of the wavelet structure
+  #pragma omp parallel for schedule(nonmonotonic : dynamic, 1)
+  for (uint64_t level = 1; level < levels; ++level) {
+    auto&& hist = ctx.hist_at_level(level);
+    const uint64_t blocks = (1 << level);
+    const uint64_t required_characters = (1 << (levels - level));
+    for (uint64_t i = 0; i < blocks; ++i) {
+      for (uint64_t j = 0; j < required_characters; ++j) {
+        hist[i] += leaf_hist[(i * required_characters) + j];
       }
     }
+  }
 
-    // Now we compute the wavelet structure bottom-up, i.e., the last level
-    // first
-    #pragma omp for
-    for (uint64_t level = 1; level < levels; ++level) {
-      // TODO: remove again
-      const uint64_t omp_rank = omp_get_thread_num();
-      DCHECK(omp_rank < levels);
-      DCHECK(omp_rank == omp_rank_);
+  // Now we compute the wavelet structure bottom-up, i.e., the last level
+  // first
+  #pragma omp parallel for schedule(nonmonotonic : dynamic, 1)
+  for (uint64_t level = 1; level < levels; ++level) {
+    const uint64_t blocks = (1 << level);
 
-      const uint64_t blocks = (1 << level);
+    auto borders = ctx.borders_at_shard(level).slice(0, blocks);
 
-      auto borders = ctx.borders_at_shard(omp_rank).slice(0, blocks);
+    compute_borders_optional_zeros_rho(level, blocks, ctx, borders);
 
-      compute_borders_optional_zeros_rho(level, blocks, ctx, borders);
-
-      // Now we insert the bits with respect to their bit prefixes
-      for (uint64_t i = 0; i < size; ++i) {
-        write_symbol_bit(bv, level, levels, borders, text[i]);
-      }
+    // Now we insert the bits with respect to their bit prefixes
+    for (uint64_t i = 0; i < size; ++i) {
+      write_symbol_bit(bv, level, levels, borders, text[i]);
     }
   }
 

--- a/include/util/common.hpp
+++ b/include/util/common.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <new>
 #include <climits>
 #include <stdint.h>
 #include <type_traits>
@@ -50,5 +51,13 @@ inline auto bit_at(const bv_t& bv, uint64_t i) -> bool {
   const uint64_t word_offset = i & MOD_MASK;
   return (bv[offset] >> (MOD_MASK - word_offset)) & 1ULL;
 }
+
+// For some reason no current C++ compiler supported this C++17 feature in 2019-03:
+// constexpr uint64_t CACHELINE_SIZE = std::hardware_destructive_interference_size;
+// So we just hardcode a suitable value here.
+// A value of 64 would be enough for current hardware generations,
+// but we pick something that is a bit more future compatible.
+
+constexpr uint64_t CACHELINE_SIZE = 128;
 
 /******************************************************************************/


### PR DESCRIPTION
This refactors the parallel sections in ppc and ppc_ss such that it scales with the `OMP_NUM_THREADS` default thread number.

It also addresses runtime performance issues in `ppc_ss` that are caused by false-sharing - ie data being to close to each other for fast parallel accesses. The fix is a general one implemented in `flat_two_dimensional_array`, and thus should make all parallel algorithms benefit from it to some extend.

closes #16
closes #17